### PR TITLE
Update the application to use the latest Swift APIs

### DIFF
--- a/App.xcodeproj/project.pbxproj
+++ b/App.xcodeproj/project.pbxproj
@@ -351,7 +351,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -408,7 +408,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
@@ -436,7 +436,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -470,7 +470,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -515,8 +515,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/couchbase/couchbase-lite-swift-ee.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 3.2.0;
+				kind = upToNextMinorVersion;
+				minimumVersion = 4.1.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/couchbase/couchbase-lite-swift-ee.git",
       "state" : {
-        "revision" : "9f9059492b0e62de848db953addbca5e1b494879",
-        "version" : "3.2.0"
+        "revision" : "b1b83765acae7f1930346189c3166f0cdee62fab",
+        "version" : "4.1.0"
       }
     }
   ],

--- a/App/App.swift
+++ b/App/App.swift
@@ -1,3 +1,4 @@
+import Observation
 import SwiftUI
 
 let appConfig = loadAppConfig()
@@ -5,19 +6,19 @@ let app = CBLApp(configuration: appConfig)
 
 @main
 struct todoSwiftUIApp: SwiftUI.App {
-    @StateObject var errorHandler = ErrorHandler(app: app)
+    @State private var errorHandler = ErrorHandler(app: app)
     private let service = { return DatabaseService() }()
-    
+
     var body: some Scene {
         WindowGroup {
             ContentView(app: app)
-                .environmentObject(CreateItemViewModel(service))
-                .environmentObject(errorHandler)
-                .environmentObject(ItemDetailViewModel(service))
-                .environmentObject(ItemsViewModel(service))
-                .environmentObject(LoginViewModel(service))
-                .environmentObject(LogoutViewModel(service))
-                .environmentObject(OpenDatabaseViewModel(service))
+                .environment(CreateItemViewModel(service))
+                .environment(errorHandler)
+                .environment(ItemDetailViewModel(service))
+                .environment(ItemsViewModel(service))
+                .environment(LoginViewModel(service))
+                .environment(LogoutViewModel(service))
+                .environment(OpenDatabaseViewModel(service))
                 .alert(Text("Error"), isPresented: .constant(errorHandler.error != nil)) {
                     Button("OK", role: .cancel) { errorHandler.error = nil }
                 } message: {
@@ -27,8 +28,9 @@ struct todoSwiftUIApp: SwiftUI.App {
     }
 }
 
-final class ErrorHandler: ObservableObject {
-    @Published var error: Swift.Error?
+@Observable
+final class ErrorHandler {
+    var error: Swift.Error?
 
     init(app: CBLApp) {
     }

--- a/App/Data/AuthenticationService.swift
+++ b/App/Data/AuthenticationService.swift
@@ -4,7 +4,7 @@ public class AuthenticationService : NSObject {
     
     private override init () { }
     
-    //create a singleton
+    // Create a singleton
     static let shared:AuthenticationService = {
         let instance = AuthenticationService()
         return instance
@@ -18,7 +18,7 @@ public class AuthenticationService : NSObject {
         guard isUrlReachable(urlString: checkUrl) else {
             throw ConnectionException(message: "Could not reach the endpoint URL.")
         }
-        //fix issue wit 401 when you don't have / at the end of the REST API
+        // Fix issue wit 401 when you don't have / at the end of the REST API
         let fixedHttpsUrl = httpsUrl + "/"
         
         guard let url = URL(string: fixedHttpsUrl) else {
@@ -33,7 +33,7 @@ public class AuthenticationService : NSObject {
         request.setValue("Basic \(encodedAuth)", forHTTPHeaderField: "Authorization")
         
         let session = URLSession(configuration: .default, delegate: self, delegateQueue: nil)
-        //let (data, response) = try await URLSession.shared.data(for: request)
+        // let (data, response) = try await URLSession.shared.data(for: request)
         let (data, response) = try await session.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse else {
             throw URLError(.badServerResponse)
@@ -74,7 +74,7 @@ public class AuthenticationService : NSObject {
         return isReachable
     }
     
-    //debug headers
+    // Debug headers
     private static func printRequestHeaders(_ request: URLRequest) {
         if let headers = request.allHTTPHeaderFields {
             for (key, value) in headers {

--- a/App/Data/CBLApp.swift
+++ b/App/Data/CBLApp.swift
@@ -1,10 +1,19 @@
 import Foundation
+import Observation
 
-class CBLApp: ObservableObject {
-    @Published var currentUser: User? = nil
-    @Published var appConfig: AppConfig
-    @Published var error: Error? = nil
-    @Published var databaseState: DatabaseState = .notInitialized
+/// Application-wide state.
+///
+/// `@Observable` replaces `ObservableObject` + `@Published`: every stored `var`
+/// is tracked individually, and a view is invalidated only by the properties it
+/// actually reads in its `body`. Because tracking is per-property rather than
+/// per-object, this works even though `app` is a plain global - views do not need
+/// to hold it in a property wrapper to observe it.
+@Observable
+class CBLApp {
+    var currentUser: User? = nil
+    var appConfig: AppConfig
+    var error: Error? = nil
+    var databaseState: DatabaseState = .notInitialized
     
     init(configuration: AppConfig){
         appConfig = configuration

--- a/App/Data/CBLApp.swift
+++ b/App/Data/CBLApp.swift
@@ -2,12 +2,6 @@ import Foundation
 import Observation
 
 /// Application-wide state.
-///
-/// `@Observable` replaces `ObservableObject` + `@Published`: every stored `var`
-/// is tracked individually, and a view is invalidated only by the properties it
-/// actually reads in its `body`. Because tracking is per-property rather than
-/// per-object, this works even though `app` is a plain global - views do not need
-/// to hold it in a property wrapper to observe it.
 @Observable
 class CBLApp {
     var currentUser: User? = nil

--- a/App/Data/DatabaseService.swift
+++ b/App/Data/DatabaseService.swift
@@ -258,6 +258,12 @@ actor DatabaseService {
     /// - SeeAlso: `InvalidStateError`
     func deleteTask(item: Item) {
         do {
+            guard let currentuser = app.currentUser
+            else {
+                app.setError(InvalidCredentialsException(
+                    message: "User is not logged in."))
+                return
+            }
             guard let collection = taskCollection
             else {
                 app.setError(InvalidStateError(
@@ -273,13 +279,18 @@ actor DatabaseService {
             //Read the stored document to verify ownership before deleting. The
             //Codable `delete(for:)` API never touches the stored document, so this
             //check has to be made explicitly.
+            //
+            //Compared against the currently logged-in user, not `item.ownerId` -
+            //`item` was decoded from this same document, so comparing to
+            //`item.ownerId` would just compare the document to itself and never
+            //reject anything.
             guard let doc = try collection.document(id: documentId)
             else {
                 app.setError(InvalidStateError(message: "document not found"))
                 return
             }
             let ownerId = doc.string(forKey: "ownerId")
-            if ownerId != item.ownerId {
+            if ownerId != currentuser.username {
                 throw InvalidStateError(
                     message: "document does not belong to current user")
             }
@@ -352,6 +363,12 @@ actor DatabaseService {
     /// - Throws: If an error occurs during document retrieval or saving, it is caught and passed to the `app.setError` function to handle the error.
     func updateItem(item: Item, isComplete: Bool, summary: String) {
         do {
+            guard let currentuser = app.currentUser
+            else {
+                app.setError(InvalidCredentialsException(
+                    message: "User is not logged in."))
+                return
+            }
             guard let collection = taskCollection
             else {
                 app.setError(InvalidStateError(
@@ -367,13 +384,18 @@ actor DatabaseService {
             //Read the stored document to verify ownership before updating. The
             //Codable `save(from:)` API never touches the stored document, so this
             //check has to be made explicitly.
+            //
+            //Compared against the currently logged-in user, not `item.ownerId` -
+            //`item` was decoded from this same document, so comparing to
+            //`item.ownerId` would just compare the document to itself and never
+            //reject anything.
             guard let doc = try collection.document(id: documentId)
             else {
                 app.setError(InvalidStateError(message: "document not found"))
                 return
             }
             let ownerId = doc.string(forKey: "ownerId")
-            if ownerId != item.ownerId {
+            if ownerId != currentuser.username {
                 throw InvalidStateError(
                     message: "document does not belong to current user")
             }

--- a/App/Data/DatabaseService.swift
+++ b/App/Data/DatabaseService.swift
@@ -1,3 +1,4 @@
+import Combine
 import CouchbaseLiteSwift
 import Foundation
 
@@ -19,8 +20,11 @@ actor DatabaseService {
     fileprivate let _taskCollectionName = "tasks"
 
     //replicator management
-    fileprivate var _replicatorStatusToken: ListenerToken? = nil
     fileprivate var _replicator: Replicator? = nil
+
+    //Combine subscriptions owned by this service. `AnyCancellable` cancels its
+    //subscription when it is released, so there are no listener tokens to remove.
+    fileprivate var cancellables = Set<AnyCancellable>()
 
     //database information
     var database: Database? = nil
@@ -30,12 +34,11 @@ actor DatabaseService {
     var queryMyTasks: Query? = nil
     var queryAllTasks: Query? = nil
 
-    //used for query listener (live query)
-    var queryListenerToken: ListenerToken? = nil
-    var taskLiveQueryObserver: (([Item]?) async -> Void)?
-
     init() {
-        Database.log.console.level = .debug
+        //`Database.log` was removed in 4.0. Logging is now configured by
+        //assigning a sink to `LogSinks`; `LogSinks.file` can be set the same way
+        //to persist logs to disk.
+        LogSinks.console = ConsoleLogSink(level: .debug)
     }
 
     /// Initializes the database for the specified user, sets up collections, indexes, queries, and replication.
@@ -98,11 +101,22 @@ actor DatabaseService {
                         withName: "idxTasksOwnerId", config: indexConfig)
 
                     //create cache queries used for LiveQuery
-                    var queryString = "SELECT * FROM data.tasks as item "
-                    self.queryAllTasks = try db.createQuery(queryString)
+                    //
+                    //`meta().id AS id` is selected explicitly so that the
+                    //`@DocumentID` property on `Item` can be populated - the
+                    //document ID lives in the document's metadata, not its body,
+                    //so `SELECT *` would not return it.
+                    //
+                    //Naming the columns (rather than using `SELECT *`) also means
+                    //each result row maps directly onto `Item`, with no wrapper
+                    //object needed to unwrap a `SELECT *` alias.
+                    let selectClause =
+                        "SELECT meta().id AS id, summary, isComplete, ownerId "
+                        + "FROM data.tasks "
+                    self.queryAllTasks = try db.createQuery(selectClause)
 
-                    queryString.append(
-                        "WHERE item.ownerId = '\(user.username)' ")
+                    var queryString = selectClause
+                    queryString.append("WHERE ownerId = '\(user.username)' ")
                     queryString.append("ORDER BY META().id ASC")
                     self.queryMyTasks = try db.createQuery(queryString)
 
@@ -115,14 +129,20 @@ actor DatabaseService {
                     }
                     let targetEndpoint = URLEndpoint(url: targetUrl)
 
+                    //configure the collection to sync
+                    //
+                    //In 4.0 the collection moved *into* `CollectionConfiguration`
+                    //and `ReplicatorConfiguration.collections` became read-only,
+                    //so collections are passed to the initializer instead of being
+                    //added afterwards - `addCollection` was removed.
+                    let collectionConfig = CollectionConfiguration(
+                        collection: collection)
+
                     //create replicator config
-                    var config = ReplicatorConfiguration(target: targetEndpoint)
+                    var config = ReplicatorConfiguration(
+                        collections: [collectionConfig], target: targetEndpoint)
                     config.replicatorType = .pushAndPull
                     config.continuous = true
-
-                    //configure collections to sync
-                    let collectionConfig = CollectionConfiguration()
-                    config.addCollection(collection, config: collectionConfig)
 
                     //add authentication
                     let auth = BasicAuthenticator(
@@ -132,16 +152,16 @@ actor DatabaseService {
                     //create the replicator
                     self._replicator = Replicator(config: config)
 
-                    //handle listeners for replication status to calculate
-                    //status change
-                    self._replicatorStatusToken = self._replicator?
-                        .addChangeListener({ (change) in
+                    //observe replication status changes
+                    self._replicator?.changePublisher()
+                        .sink { (change) in
                             if let error = change.status.error {
                                 print("replicator error state \(error)")
                             } else {
                                 print("current state \(change.status.activity)")
                             }
-                        })
+                        }
+                        .store(in: &cancellables)
 
                     if let replicator = self._replicator {
                         replicator.start()
@@ -187,27 +207,23 @@ actor DatabaseService {
             let task = Item(
                 isComplete: false, summary: taskSummary,
                 ownerId: currentuser.username)
-            if let json = task.toJSON() {
-                let mutableDocument = try MutableDocument(
-                    id: task.id, json: json)
-                try collection.save(document: mutableDocument)
-            } else {
-                app.setError(InvalidStateError(
-                    message: "item could not be serialized"))
-            }
+
+            //`save(from:)` encodes the Codable object directly. `task.id` is nil
+            //here, so Couchbase Lite generates a document ID and writes it back
+            //to the `@DocumentID` property.
+            try collection.save(from: task)
 
         } catch {
             app.setError(error)
         }
     }
 
-    /// Closes the database and stops any active listeners and replicators.
+    /// Closes the database and stops any active subscriptions and replicators.
     ///
     /// This function performs the following actions in sequence:
-    /// 1. Removes the query listener token, if it exists, to stop observing query changes.
-    /// 2. Removes the replicator status token, if it exists, to stop monitoring replicator status updates.
-    /// 3. Stops the replicator if it is currently running.
-    /// 4. Closes the database connection safely.
+    /// 1. Cancels this service's Combine subscriptions, which stops observing replicator status.
+    /// 2. Stops the replicator if it is currently running.
+    /// 3. Closes the database connection safely.
     ///
     /// If an error occurs during any of these operations, it is caught and stored in the application's error state.
     ///
@@ -217,8 +233,7 @@ actor DatabaseService {
     ///   to ensure resources are released properly and replication is stopped.
     func close() {
         do {
-            self.queryListenerToken?.remove()
-            self._replicatorStatusToken?.remove()
+            self.cancellables.removeAll()
             self._replicator?.stop()
             try self.database?.close()
         } catch {
@@ -249,7 +264,16 @@ actor DatabaseService {
                     message: "taskCollection is not available."))
                 return
             }
-            guard let doc = try collection.document(id: item.id)
+            guard let documentId = item.id
+            else {
+                app.setError(InvalidStateError(
+                    message: "item has not been saved and has no document id"))
+                return
+            }
+            //Read the stored document to verify ownership before deleting. The
+            //Codable `delete(for:)` API never touches the stored document, so this
+            //check has to be made explicitly.
+            guard let doc = try collection.document(id: documentId)
             else {
                 app.setError(InvalidStateError(message: "document not found"))
                 return
@@ -259,71 +283,27 @@ actor DatabaseService {
                 throw InvalidStateError(
                     message: "document does not belong to current user")
             }
-            try collection.delete(document: doc)
+            try collection.delete(for: item)
         } catch {
             app.setError(error)
         }
     }
 
-    /// Sets up a live query observer to monitor changes in the task list based on the specified subscription type.
+    /// Returns the cached live query for the given subscription type.
     ///
-    /// This function sets an observer that listens for changes in the task list using a live query. Depending on the
-    /// provided subscription type, it runs either the query for all tasks or the query for the current user's tasks.
-    /// When the query detects changes, the observer is called with the updated list of tasks. If an observer is already
-    /// set, it removes the existing listener before setting up a new one.
+    /// The caller subscribes to the returned query with `changePublisher()` and owns
+    /// the resulting subscription, so the view model - not this service - decides when
+    /// observation starts and stops.
     ///
-    /// - Parameters:
-    ///   - subscriptionType: A `String` representing the type of subscription for the task list.
-    ///     Use `Constants.allItems` to observe all tasks or `Constants.myItems` for observing the current user's tasks.
-    ///   - observer: An optional closure `(([Item]?) -> Void)?` that is called with the updated list of tasks when
-    ///     changes are detected by the live query. If `nil`, the function will remove any existing query listener.
+    /// - Parameter subscriptionType: Use `Constants.allItems` for every task, or
+    ///   `Constants.myItems` for only the signed-in user's tasks.
     ///
-    /// - Important: Ensure that the subscription type matches the constants used to differentiate between all tasks
-    ///   and user-specific tasks. If the subscription type is not recognized, the function may not set up the appropriate query.
-    ///
-    /// - Note: If an observer is already active when this function is called, the existing query listener token will be
-    ///   removed before adding the new listener.
+    /// - Returns: The corresponding `Query`, or `nil` if the database has not been
+    ///   initialized yet.
     ///
     /// - SeeAlso: `Constants.allItems`, `Constants.myItems`
-    func setTasksListChangeObserver(
-        subscriptionType: String, observer: (([Item]?) async -> Void)?
-    ) {
-        taskLiveQueryObserver = observer
-        var query: Query? = nil
-
-        if taskLiveQueryObserver != nil {
-            //if existing query listener is running, remove it
-            if let token = queryListenerToken {
-                token.remove()
-            }
-
-            //figure out which query to run
-            if subscriptionType == Constants.allItems {
-                query = queryAllTasks
-            } else {
-                query = queryMyTasks
-            }
-            if let runQuery = query {
-                queryListenerToken =
-                    runQuery
-                    .addChangeListener({[weak self] (change) in
-                        var items: [Item] = []
-                        if let results = change.results {
-                            for result in results {
-                                let json = result.toJSON()
-                                if let itemDao = ItemDao(json: json) {
-                                    items.append(itemDao.item)
-                                } else {
-                                    print("error deserializing item from query")
-                                }
-                            }
-                            Task {
-                                await self?.taskLiveQueryObserver?(items)
-                            }
-                        }
-                    })
-            }
-        }
+    func tasksQuery(subscriptionType: String) -> Query? {
+        subscriptionType == Constants.allItems ? queryAllTasks : queryMyTasks
     }
 
     /// Pauses the synchronization process by stopping the replicator.
@@ -378,7 +358,16 @@ actor DatabaseService {
                     message: "taskCollection is not available."))
                 return
             }
-            guard let doc = try collection.document(id: item.id)
+            guard let documentId = item.id
+            else {
+                app.setError(InvalidStateError(
+                    message: "item has not been saved and has no document id"))
+                return
+            }
+            //Read the stored document to verify ownership before updating. The
+            //Codable `save(from:)` API never touches the stored document, so this
+            //check has to be made explicitly.
+            guard let doc = try collection.document(id: documentId)
             else {
                 app.setError(InvalidStateError(message: "document not found"))
                 return
@@ -388,10 +377,9 @@ actor DatabaseService {
                 throw InvalidStateError(
                     message: "document does not belong to current user")
             }
-            let mutableDoc = doc.toMutable()
-            mutableDoc.setBoolean(isComplete, forKey: "isComplete")
-            mutableDoc.setString(summary, forKey: "summary")
-            try collection.save(document: mutableDoc)
+            item.isComplete = isComplete
+            item.summary = summary
+            try collection.save(from: item)
         } catch {
             app.setError(error)
         }

--- a/App/Data/DatabaseService.swift
+++ b/App/Data/DatabaseService.swift
@@ -188,7 +188,7 @@ actor DatabaseService {
     func addTask(taskSummary: String) {
         do {
             // validate the user is logged in
-            guard let currentuser = requireCurrentUser() else { return }
+            guard let currentUser = requireCurrentUser() else { return }
             guard let collection = taskCollection
             else {
                 app.setError(InvalidStateError(
@@ -197,7 +197,7 @@ actor DatabaseService {
             }
             let task = Item(
                 isComplete: false, summary: taskSummary,
-                ownerId: currentuser.username)
+                ownerId: currentUser.username)
 
             // `save(from:)` encodes the Codable object directly. `task.id` is nil
             // here, so Couchbase Lite generates a document ID and writes it back
@@ -254,7 +254,7 @@ actor DatabaseService {
     /// - SeeAlso: `InvalidStateError`
     func deleteTask(item: Item) {
         do {
-            guard let currentuser = requireCurrentUser() else { return }
+            guard let currentUser = requireCurrentUser() else { return }
             guard let collection = taskCollection
             else {
                 app.setError(InvalidStateError(
@@ -285,7 +285,7 @@ actor DatabaseService {
                 return
             }
             let ownerId = doc.string(forKey: "ownerId")
-            if ownerId != currentuser.username {
+            if ownerId != currentUser.username {
                 throw InvalidStateError(
                     message: "document does not belong to current user")
             }
@@ -395,7 +395,7 @@ actor DatabaseService {
     /// - Throws: If an error occurs during document retrieval or saving, it is caught and passed to the `app.setError` function to handle the error.
     func updateItem(item: Item, isComplete: Bool, summary: String) {
         do {
-            guard let currentuser = requireCurrentUser() else { return }
+            guard let currentUser = requireCurrentUser() else { return }
             guard let collection = taskCollection
             else {
                 app.setError(InvalidStateError(
@@ -425,7 +425,7 @@ actor DatabaseService {
                 return
             }
             let ownerId = doc.string(forKey: "ownerId")
-            if ownerId != currentuser.username {
+            if ownerId != currentUser.username {
                 throw InvalidStateError(
                     message: "document does not belong to current user")
             }

--- a/App/Data/DatabaseService.swift
+++ b/App/Data/DatabaseService.swift
@@ -3,41 +3,41 @@ import CouchbaseLiteSwift
 import Foundation
 
 public enum DatabaseState {
-    //database is not initialized
+    // database is not initialized
     case notInitialized
-    //Starting the Replicator Sync process
+    // Starting the Replicator Sync process
     case connecting
-    //The database has been opened and is ready for use.
+    // The database has been opened and is ready for use.
     case open
-    //Opening the database or the replicator sync failed
+    // Opening the database or the replicator sync failed
     case error(Error)
 }
 
 actor DatabaseService {
 
-    //scope and collection information
+    // scope and collection information
     fileprivate let _scopeName = "data"
     fileprivate let _taskCollectionName = "tasks"
 
-    //replicator management
+    // replicator management
     fileprivate var _replicator: Replicator? = nil
 
-    //Combine subscriptions owned by this service. `AnyCancellable` cancels its
-    //subscription when it is released, so there are no listener tokens to remove.
+    // Combine subscriptions owned by this service. `AnyCancellable` cancels its
+    // subscription when it is released, so there are no listener tokens to remove.
     fileprivate var cancellables = Set<AnyCancellable>()
 
-    //database information
+    // database information
     var database: Database? = nil
     var taskCollection: Collection? = nil
 
-    //cached queries
+    // cached queries
     var queryMyTasks: Query? = nil
     var queryAllTasks: Query? = nil
 
     init() {
-        //`Database.log` was removed in 4.0. Logging is now configured by
-        //assigning a sink to `LogSinks`; `LogSinks.file` can be set the same way
-        //to persist logs to disk.
+        // `Database.log` was removed in 4.0. Logging is now configured by
+        // assigning a sink to `LogSinks`; `LogSinks.file` can be set the same way
+        // to persist logs to disk.
         LogSinks.console = ConsoleLogSink(level: .debug)
     }
 
@@ -81,46 +81,29 @@ actor DatabaseService {
 
             app.setDatabaseState(.notInitialized)
 
-            //get santised username to use in database name
+            // get santised username to use in database name
             let username = user.username
                 .replacingOccurrences(of: "@", with: "-")
                 .replacingOccurrences(of: ".", with: "-")
             let databaseName = "tasks-\(username)"
 
-            //open database
+            // open database
             self.database = try Database(name: databaseName)
             if let db = self.database {
-                //get the collection - create collection with either create a collection
-                //or if it already exist, return the existing collection
+                // get the collection - create collection with either create a collection
+                // or if it already exist, return the existing collection
                 self.taskCollection = try db.createCollection(
                     name: _taskCollectionName, scope: _scopeName)
                 if let collection = self.taskCollection {
-                    //create index
+                    // create index
                     let indexConfig = ValueIndexConfiguration(["ownerId"])
                     try collection.createIndex(
                         withName: "idxTasksOwnerId", config: indexConfig)
 
-                    //create cache queries used for LiveQuery
-                    //
-                    //`meta().id AS id` is selected explicitly so that the
-                    //`@DocumentID` property on `Item` can be populated - the
-                    //document ID lives in the document's metadata, not its body,
-                    //so `SELECT *` would not return it.
-                    //
-                    //Naming the columns (rather than using `SELECT *`) also means
-                    //each result row maps directly onto `Item`, with no wrapper
-                    //object needed to unwrap a `SELECT *` alias.
-                    let selectClause =
-                        "SELECT meta().id AS id, summary, isComplete, ownerId "
-                        + "FROM data.tasks "
-                    self.queryAllTasks = try db.createQuery(selectClause)
+                    // create cache queries used for LiveQuery
+                    try createTaskQueries(in: db, for: user)
 
-                    var queryString = selectClause
-                    queryString.append("WHERE ownerId = '\(user.username)' ")
-                    queryString.append("ORDER BY META().id ASC")
-                    self.queryMyTasks = try db.createQuery(queryString)
-
-                    //setup replicator
+                    // setup replicator
                     guard let targetUrl = URL(string: app.appConfig.endpointUrl)
                     else {
                         app.error = InvalidEndpointUrl(
@@ -129,30 +112,30 @@ actor DatabaseService {
                     }
                     let targetEndpoint = URLEndpoint(url: targetUrl)
 
-                    //configure the collection to sync
+                    // configure the collection to sync
                     //
-                    //In 4.0 the collection moved *into* `CollectionConfiguration`
-                    //and `ReplicatorConfiguration.collections` became read-only,
-                    //so collections are passed to the initializer instead of being
-                    //added afterwards - `addCollection` was removed.
+                    // In 4.0 the collection moved *into* `CollectionConfiguration`
+                    // and `ReplicatorConfiguration.collections` became read-only,
+                    // so collections are passed to the initializer instead of being
+                    // added afterwards - `addCollection` was removed.
                     let collectionConfig = CollectionConfiguration(
                         collection: collection)
 
-                    //create replicator config
+                    // create replicator config
                     var config = ReplicatorConfiguration(
                         collections: [collectionConfig], target: targetEndpoint)
                     config.replicatorType = .pushAndPull
                     config.continuous = true
 
-                    //add authentication
+                    // add authentication
                     let auth = BasicAuthenticator(
                         username: user.username, password: user.password)
                     config.authenticator = auth
 
-                    //create the replicator
+                    // create the replicator
                     self._replicator = Replicator(config: config)
 
-                    //observe replication status changes
+                    // observe replication status changes
                     self._replicator?.changePublisher()
                         .sink { (change) in
                             if let error = change.status.error {
@@ -174,6 +157,19 @@ actor DatabaseService {
         }
     }
 
+    /// Returns the signed-in user, or `nil` after setting an `InvalidCredentialsException`
+    /// in the app's error state.
+    ///
+    private func requireCurrentUser() -> User? {
+        guard let currentUser = app.currentUser
+        else {
+            app.setError(InvalidCredentialsException(
+                message: "User is not logged in."))
+            return nil
+        }
+        return currentUser
+    }
+
     /// Adds a task to the database with the specified summary.
     ///
     /// This function validates the currently logged-in user and adds a new task to the `taskCollection` if available.
@@ -191,13 +187,8 @@ actor DatabaseService {
     /// - SeeAlso: `InvalidCredentialsException`, `InvalidStateError`
     func addTask(taskSummary: String) {
         do {
-            //validate the user is logged in
-            guard let currentuser = app.currentUser
-            else {
-                app.setError(InvalidCredentialsException(
-                    message: "User is not logged in."))
-                return
-            }
+            // validate the user is logged in
+            guard let currentuser = requireCurrentUser() else { return }
             guard let collection = taskCollection
             else {
                 app.setError(InvalidStateError(
@@ -208,9 +199,9 @@ actor DatabaseService {
                 isComplete: false, summary: taskSummary,
                 ownerId: currentuser.username)
 
-            //`save(from:)` encodes the Codable object directly. `task.id` is nil
-            //here, so Couchbase Lite generates a document ID and writes it back
-            //to the `@DocumentID` property.
+            // `save(from:)` encodes the Codable object directly. `task.id` is nil
+            // here, so Couchbase Lite generates a document ID and writes it back
+            // to the `@DocumentID` property.
             try collection.save(from: task)
 
         } catch {
@@ -244,26 +235,26 @@ actor DatabaseService {
     /// Deletes a specified task from the database.
     ///
     /// This function attempts to locate and delete a task document from the `taskCollection` based on the provided item's ID.
-    /// If the task collection or document is not available, it sets an appropriate error in the app's error state and
+    /// If the task collection is not available, it sets an appropriate error in the app's error state and
     /// exits early. Any other errors encountered during deletion are caught and handled.
+    ///
+    /// A document that no longer exists is treated as success rather than as an error: it may
+    /// have been deleted on another device and that deletion replicated to this one, in which
+    /// case the requested end state has already been reached.
     ///
     /// - Parameter item: An `Item` representing the task to be deleted. The function uses the `id` property of the `Item`
     ///   to locate the corresponding document in the database.
     ///
     /// - Important: Ensure that the `taskCollection` is properly initialized and accessible before calling this function.
-    ///   If the `taskCollection` or the document does not exist, an `InvalidStateError` is set in the app's error state.
+    ///   If the `taskCollection` does not exist, or the document belongs to another user, an `InvalidStateError` is set
+    ///   in the app's error state.
     ///
     /// - Throws: An error if there is an issue retrieving or deleting the document in the collection.
     ///
     /// - SeeAlso: `InvalidStateError`
     func deleteTask(item: Item) {
         do {
-            guard let currentuser = app.currentUser
-            else {
-                app.setError(InvalidCredentialsException(
-                    message: "User is not logged in."))
-                return
-            }
+            guard let currentuser = requireCurrentUser() else { return }
             guard let collection = taskCollection
             else {
                 app.setError(InvalidStateError(
@@ -276,17 +267,21 @@ actor DatabaseService {
                     message: "item has not been saved and has no document id"))
                 return
             }
-            //Read the stored document to verify ownership before deleting. The
-            //Codable `delete(for:)` API never touches the stored document, so this
-            //check has to be made explicitly.
+            // Read the stored document to verify ownership before deleting.
             //
-            //Compared against the currently logged-in user, not `item.ownerId` -
-            //`item` was decoded from this same document, so comparing to
-            //`item.ownerId` would just compare the document to itself and never
-            //reject anything.
+            // Neither delete API validates the stored document, so ownership cannot be
+            // enforced by the delete call itself - it has to be checked here.
+            //
+            // Compared against the currently logged-in user, not `item.ownerId` -
+            // `item` was decoded from this same document, so comparing to
+            // `item.ownerId` would just compare the document to itself and never
+            // reject anything.
             guard let doc = try collection.document(id: documentId)
             else {
-                app.setError(InvalidStateError(message: "document not found"))
+                // The document is already gone - most likely deleted on another device
+                // with that deletion pulled down by replication. The caller asked for
+                // it to be deleted and it is, so there is nothing to do and nothing to
+                // report.
                 return
             }
             let ownerId = doc.string(forKey: "ownerId")
@@ -294,10 +289,47 @@ actor DatabaseService {
                 throw InvalidStateError(
                     message: "document does not belong to current user")
             }
-            try collection.delete(for: item)
+            // Deleted through the `Document` already read above rather than through the
+            // Codable `delete(for:)`. No extra read is needed since the ownership check
+            // has the document in hand, and this form is idempotent: if replication
+            // removes the document in the window between the check and this call, the
+            // delete still succeeds. `delete(for:)` instead fails that race with
+            // "Cannot delete a document that has not yet been saved."
+            try collection.delete(document: doc)
         } catch {
             app.setError(error)
         }
+    }
+
+    /// Builds the two cached queries that back the live task list.
+    ///
+    /// `meta().id AS id` is selected explicitly so that the `@DocumentID` property on
+    /// `Item` can be populated - the document ID lives in the document's metadata, not
+    /// its body, so `SELECT *` would not return it.
+    ///
+    /// Naming the columns (rather than using `SELECT *`) also means each result row maps
+    /// directly onto `Item`, with no wrapper object needed to unwrap a `SELECT *` alias.
+    ///
+    /// Called while the database is being opened rather than lazily from `tasksQuery`,
+    /// because a `Query` is bound to the `Database` it was created from and `queryMyTasks`
+    /// filters on the user that database was opened for. Building them here keeps both
+    /// tied to the same lifetime as the database itself.
+    ///
+    /// - Parameters:
+    ///   - db: The database the queries are created against.
+    ///   - user: The signed-in user, whose `username` scopes `queryMyTasks`.
+    ///
+    /// - Throws: An error if either query fails to compile.
+    private func createTaskQueries(in db: Database, for user: User) throws {
+        let selectClause =
+            "SELECT meta().id AS id, summary, isComplete, ownerId " +
+            "FROM data.tasks "
+        self.queryAllTasks = try db.createQuery(selectClause)
+
+        var queryString = selectClause
+        queryString.append("WHERE ownerId = '\(user.username)' ")
+        queryString.append("ORDER BY META().id ASC")
+        self.queryMyTasks = try db.createQuery(queryString)
     }
 
     /// Returns the cached live query for the given subscription type.
@@ -363,12 +395,7 @@ actor DatabaseService {
     /// - Throws: If an error occurs during document retrieval or saving, it is caught and passed to the `app.setError` function to handle the error.
     func updateItem(item: Item, isComplete: Bool, summary: String) {
         do {
-            guard let currentuser = app.currentUser
-            else {
-                app.setError(InvalidCredentialsException(
-                    message: "User is not logged in."))
-                return
-            }
+            guard let currentuser = requireCurrentUser() else { return }
             guard let collection = taskCollection
             else {
                 app.setError(InvalidStateError(
@@ -381,14 +408,17 @@ actor DatabaseService {
                     message: "item has not been saved and has no document id"))
                 return
             }
-            //Read the stored document to verify ownership before updating. The
-            //Codable `save(from:)` API never touches the stored document, so this
-            //check has to be made explicitly.
+            // Read the stored document to verify ownership before updating.
             //
-            //Compared against the currently logged-in user, not `item.ownerId` -
-            //`item` was decoded from this same document, so comparing to
-            //`item.ownerId` would just compare the document to itself and never
-            //reject anything.
+            // `save(from:)` writes the encoded object to the document ID taken from the
+            // object's `@DocumentID`. It does not compare the object against what is
+            // already stored there, so on its own it would let one user's write land on
+            // another user's task - the check has to be made here.
+            //
+            // Compared against the currently logged-in user, not `item.ownerId` -
+            // `item` was decoded from this same document, so comparing to
+            // `item.ownerId` would just compare the document to itself and never
+            // reject anything.
             guard let doc = try collection.document(id: documentId)
             else {
                 app.setError(InvalidStateError(message: "document not found"))

--- a/App/Models/Item.swift
+++ b/App/Models/Item.swift
@@ -1,84 +1,36 @@
+import CouchbaseLiteSwift
 import Foundation
 
-class ItemDao : Codable {
-    var item: Item
-    
-    init (item: Item){
-        self.item = item
-    }
-    
-    convenience init?(json: String) {
-        guard let data = json.data(using: .utf8) else { return nil }
-        do {
-            let item = try JSONDecoder().decode(ItemDao.self, from: data)
-            self.init(item: item.item)
-        } catch {
-            print ("ItemDao Error Init: \(error)")
-            return nil
-        }
-    }
-}
+/// A single to-do task.
+///
+/// `Codable` conformance is synthesized by the compiler. The property names match
+/// the column aliases selected by the queries in `DatabaseService`, so no
+/// `CodingKeys` mapping is required.
+class Item: Codable, Identifiable {
 
-class Item : Codable, Identifiable {
-    var id: String
-    var isComplete: Bool = false
+    /// Bound to the document's *metadata* ID rather than to a field in the document
+    /// body, via the `@DocumentID` property wrapper.
+    ///
+    /// This is `nil` for an item that has not been saved yet; Couchbase Lite assigns
+    /// an ID on save. When an item is decoded from a query result, the value comes
+    /// from the `meta().id AS id` column — which is why that column must be present
+    /// in every query that produces an `Item`.
+    @DocumentID var id: String?
+
+    /// Optional so that a document written without this field still decodes,
+    /// rather than failing the whole row.
+    var isComplete: Bool?
+
     var summary: String
     var ownerId: String
-    
-    init(id: String = UUID().uuidString.lowercased(),
-         isComplete: Bool = false,
+
+    init(id: String? = nil,
+         isComplete: Bool? = false,
          summary: String,
          ownerId: String) {
         self.id = id
         self.isComplete = isComplete
         self.summary = summary
         self.ownerId = ownerId
-    }
-
-    // Initialize from JSON string
-    convenience init?(json: String) {
-        guard let data = json.data(using: .utf8) else { return nil }
-        do {
-            let item = try JSONDecoder().decode(Item.self, from: data)
-            self.init(id: item.id, isComplete: item.isComplete, summary: item.summary, ownerId: item.ownerId)
-        } catch {
-            return nil
-        }
-    }
-    
-    // Custom decoding initializer
-    required init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.id = try container.decode(String.self, forKey: .id)
-        self.summary = try container.decode(String.self, forKey: .summary)
-        self.ownerId = try container.decode(String.self, forKey: .ownerId)
-        // Provide a default value for isComplete if it is missing
-        self.isComplete = try container.decodeIfPresent(Bool.self, forKey: .isComplete) ?? false
-    }
-    
-    // Encoding function (no change needed)
-    func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(id, forKey: .id)
-        try container.encode(isComplete, forKey: .isComplete)
-        try container.encode(summary, forKey: .summary)
-        try container.encode(ownerId, forKey: .ownerId)
-    }
-    
-    enum CodingKeys: String, CodingKey {
-        case id
-        case isComplete
-        case summary
-        case ownerId
-    }
-    
-    // Serialize to JSON string
-    func toJSON() -> String? {
-        do {
-            let data = try JSONEncoder().encode(self)
-            return String(data: data, encoding: .utf8)
-        } catch {
-            return nil
-        }
     }
 }

--- a/App/ViewModels/CreateItemViewModel.swift
+++ b/App/ViewModels/CreateItemViewModel.swift
@@ -14,7 +14,7 @@ class CreateItemViewModel {
 
     func createItem() async {
         await service.addTask(taskSummary: itemSummary)
-        //reset summary for next creation
+        // reset summary for next creation
         self.itemSummary = ""
     }
 }

--- a/App/ViewModels/CreateItemViewModel.swift
+++ b/App/ViewModels/CreateItemViewModel.swift
@@ -1,8 +1,10 @@
 import Foundation
+import Observation
 
+@Observable
 @MainActor
-class CreateItemViewModel: ObservableObject {
-    @Published var itemSummary = ""
+class CreateItemViewModel {
+    var itemSummary = ""
 
     let service: DatabaseService
 

--- a/App/ViewModels/ItemDetailViewModel.swift
+++ b/App/ViewModels/ItemDetailViewModel.swift
@@ -1,13 +1,17 @@
 import Foundation
+import Observation
 
+/// Holds no state of its own, but must still be `@Observable`: `@Environment`
+/// can only resolve objects whose type conforms to `Observable`.
+@Observable
 @MainActor
-class ItemDetailViewModel : ObservableObject {
+class ItemDetailViewModel {
     let service: DatabaseService
-    
+
     init(_ service:DatabaseService) {
         self.service = service
     }
-    
+
     func updateItem(item: Item, isComplete:Bool, newSummary: String) async {
         await service.updateItem(item: item, isComplete: isComplete, summary: newSummary)
     }

--- a/App/ViewModels/ItemsViewModel.swift
+++ b/App/ViewModels/ItemsViewModel.swift
@@ -50,7 +50,18 @@ class ItemsViewModel {
 
         guard let query = await service.tasksQuery(
             subscriptionType: subscriptionType)
-        else { return }
+        else {
+            // The cached queries are created while the database is being opened, and
+            // this view model is only reachable once `databaseState` is `.open`, so a
+            // nil query means that invariant has broken rather than a condition the
+            // app should expect. `assertionFailure` traps in debug builds to surface
+            // it, and is compiled out of release builds - where returning leaves the
+            // list empty instead of crashing.
+            assertionFailure(
+                "No cached query for subscriptionType '\(subscriptionType)' - "
+                + "the database should have been initialized before observing tasks")
+            return
+        }
 
         query.changePublisher()
             .map { change -> [Item] in

--- a/App/ViewModels/ItemsViewModel.swift
+++ b/App/ViewModels/ItemsViewModel.swift
@@ -1,12 +1,25 @@
+import Combine
+import CouchbaseLiteSwift
 import Foundation
+import Observation
 
+@Observable
 @MainActor
-class ItemsViewModel: ObservableObject {
-    @Published var items: [Item] = []
-    @Published var isInCreateItemView = false
-    @Published var showOfflineNote = false
+class ItemsViewModel {
+    var items: [Item] = []
+    var isInCreateItemView = false
+    var showOfflineNote = false
 
     let service: DatabaseService
+
+    /// Holds the live query subscription. Releasing the `AnyCancellable` cancels the
+    /// underlying query listener, so there is no token to remove by hand.
+    ///
+    /// Marked `@ObservationIgnored` because this is replication plumbing, not view
+    /// state - without it, storing a subscription would invalidate every view that
+    /// reads this object.
+    @ObservationIgnored
+    private var cancellables = Set<AnyCancellable>()
 
     init(_ service: DatabaseService) {
         self.service = service
@@ -17,22 +30,36 @@ class ItemsViewModel: ObservableObject {
     }
 
     func setAllItems() async {
-        await service.setTasksListChangeObserver(
-            subscriptionType: Constants.allItems,
-            observer: updateItems)
+        await observeTasks(subscriptionType: Constants.allItems)
     }
 
     func setMyItems() async {
-        await service.setTasksListChangeObserver(
-            subscriptionType: Constants.myItems,
-            observer: updateItems)
+        await observeTasks(subscriptionType: Constants.myItems)
     }
 
-    func updateItems(newItems: [Item]?) async {
-        self.items.removeAll()
-        if let nis = newItems {
-            self.items.append(contentsOf: nis)
-        }
-    }
+    /// Subscribes to the live query for the given subscription type and keeps
+    /// `items` in step with it.
+    ///
+    /// Any previous subscription is cancelled first, so toggling between "my tasks"
+    /// and "all tasks" swaps cleanly rather than leaving two live queries running.
+    ///
+    /// The publisher delivers on the main queue by default, and emits the *entire*
+    /// result set on every change - so `items` is replaced, never appended to.
+    private func observeTasks(subscriptionType: String) async {
+        cancellables.removeAll()
 
+        guard let query = await service.tasksQuery(
+            subscriptionType: subscriptionType)
+        else { return }
+
+        query.changePublisher()
+            .map { change -> [Item] in
+                guard let results = change.results else { return [] }
+                return (try? results.data(as: Item.self)) ?? []
+            }
+            .sink { [weak self] items in
+                self?.items = items
+            }
+            .store(in: &cancellables)
+    }
 }

--- a/App/ViewModels/LoginViewModel.swift
+++ b/App/ViewModels/LoginViewModel.swift
@@ -1,22 +1,24 @@
 import Foundation
+import Observation
 
+@Observable
 @MainActor
-class LoginViewModel : ObservableObject {
+class LoginViewModel {
     let service: DatabaseService
-    
-    @Published var email = ""
-    @Published var password = ""
-    @Published var isLoggingIn = false
-    
+
+    var email = ""
+    var password = ""
+    var isLoggingIn = false
+
     init(_ service:DatabaseService) {
         self.service = service
     }
-    
+
     func setDefaultUsernamePassword() {
         email = "demo1@example.com"
         password = "P@ssw0rd12"
     }
-    
+
     func login() async throws  {
         do {
             self.isLoggingIn = true
@@ -33,5 +35,5 @@ class LoginViewModel : ObservableObject {
             throw error
         }
     }
-    
+
 }

--- a/App/ViewModels/LogoutViewModel.swift
+++ b/App/ViewModels/LogoutViewModel.swift
@@ -1,16 +1,18 @@
 import Foundation
+import Observation
 
+@Observable
 @MainActor
-class LogoutViewModel : ObservableObject {
+class LogoutViewModel {
     var isLoggingOut = false
     var errorMessage: ErrorMessage? = nil
     var error: Error?
     let service: DatabaseService
-    
+
     init(_ service:DatabaseService) {
         self.service = service
     }
-    
+
     func logout() async {
         await service.close()
         app.currentUser = nil

--- a/App/ViewModels/OpenDatabaseViewModel.swift
+++ b/App/ViewModels/OpenDatabaseViewModel.swift
@@ -1,17 +1,21 @@
 import Foundation
+import Observation
 
+/// Holds no state of its own, but must still be `@Observable`: `@Environment`
+/// can only resolve objects whose type conforms to `Observable`.
+@Observable
 @MainActor
-class OpenDatabaseViewModel : ObservableObject {
+class OpenDatabaseViewModel {
     let service: DatabaseService
-    
+
     init(_ service:DatabaseService) {
         self.service = service
     }
-    
+
     func pauseSync() async {
         await service.pauseSync()
     }
-    
+
     func resumeSync() async {
         await service.resumeSync()
     }

--- a/App/Views/Components/ItemDetail.swift
+++ b/App/Views/Components/ItemDetail.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 /// Show a detail view of a task Item. User can edit the summary or mark the Item complete.
 struct ItemDetail: View {
-    @EnvironmentObject var viewModel:ItemDetailViewModel
+    @Environment(ItemDetailViewModel.self) private var viewModel
     @Environment(\.presentationMode) var presentationMode // Access the presentation mode
 
     
@@ -14,7 +14,7 @@ struct ItemDetail: View {
     
     init (item: Item){
         _summaryText = State(initialValue: item.summary)
-        _isCompleteToggleState = State(initialValue: item.isComplete)
+        _isCompleteToggleState = State(initialValue: item.isComplete ?? false)
         _item = State(initialValue: item)
     }
     

--- a/App/Views/Components/ItemList.swift
+++ b/App/Views/Components/ItemList.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 /// view a list of all Items in the collection. User can swipe to delete Items.
 struct ItemList: View {
-    @EnvironmentObject var viewModel: ItemsViewModel
+    @Environment(ItemsViewModel.self) private var viewModel
     var body: some View {
         VStack {
             List {

--- a/App/Views/Components/ItemList.swift
+++ b/App/Views/Components/ItemList.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-/// view a list of all Items in the collection. User can swipe to delete Items.
+/// view a list of all Items in the collection. User can swipe to delete their own Items.
 struct ItemList: View {
     @Environment(ItemsViewModel.self) private var viewModel
     var body: some View {
@@ -8,8 +8,24 @@ struct ItemList: View {
             List {
                 ForEach(viewModel.items) { item in
                     ItemRow(item: item)
+                        // `.onDelete` on the `ForEach` would offer swipe-to-delete on every
+                        // row uniformly - there is no per-row way to opt out of it. Using
+                        // `.swipeActions` per row instead means the delete button (and the
+                        // swipe gesture) only exists on rows the current user owns; other
+                        // rows have no swipe action at all, matching the "owner only" rule
+                        // `ItemDetail` already enforces for editing.
+                        .swipeActions(edge: .trailing) {
+                            if app.currentUser?.username == item.ownerId {
+                                Button(role: .destructive) {
+                                    Task {
+                                        await viewModel.delete(item: item)
+                                    }
+                                } label: {
+                                    Label("Delete", systemImage: "trash")
+                                }
+                            }
+                        }
                 }
-                .onDelete(perform: deleteItems)
             }
             .listStyle(InsetListStyle())
             Spacer()
@@ -20,14 +36,5 @@ struct ItemList: View {
             Spacer()
         }
         .navigationBarTitle("Items", displayMode: .inline)
-    }
-    
-    func deleteItems(at offsets: IndexSet) {
-        let itemsToDelete = offsets.map { viewModel.items[$0] }
-        for item in itemsToDelete {
-            Task {
-                await viewModel.delete(item: item)
-            }
-        }
     }
 }

--- a/App/Views/Components/ItemList.swift
+++ b/App/Views/Components/ItemList.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-/// view a list of all Items in the collection. User can swipe to delete their own Items.
+/// View a list of all Items in the collection. User can swipe to delete their own Items.
 struct ItemList: View {
     @Environment(ItemsViewModel.self) private var viewModel
     var body: some View {

--- a/App/Views/Components/ItemRow.swift
+++ b/App/Views/Components/ItemRow.swift
@@ -7,7 +7,7 @@ struct ItemRow: View {
         NavigationLink(destination: ItemDetail(item: item)) {
             Text(item.summary)
             Spacer()
-            if item.isComplete {
+            if item.isComplete == true {
                 Image(systemName: "checkmark")
                     .foregroundColor(.blue)
                     .padding(.trailing, 10)

--- a/App/Views/Components/LogoutButton.swift
+++ b/App/Views/Components/LogoutButton.swift
@@ -2,27 +2,36 @@ import SwiftUI
 
 /// Logout from the synchronized realm. Returns the user to the login/sign up screen.
 struct LogoutButton: View {
-    @EnvironmentObject var viewModel: LogoutViewModel
+    @Environment(LogoutViewModel.self) private var viewModel
+
     var body: some View {
-        if viewModel.isLoggingOut {
-            ProgressView()
-        }
-        Button("Log Out") {
-            viewModel.isLoggingOut = true
-            Task {
-                logout()
+        // `@Bindable` is what makes `$viewModel.errorMessage` available for an
+        // `@Observable` object resolved from the environment.
+        @Bindable var viewModel = viewModel
+
+        // Declaring the shadow above makes this a normal function body rather than
+        // an implicit `ViewBuilder` one, so the two views are grouped explicitly.
+        return Group {
+            if viewModel.isLoggingOut {
+                ProgressView()
             }
-        }.disabled(app.currentUser == nil || viewModel.isLoggingOut)
-        // Show an alert if there is an error during logout
-            .alert(item: $viewModel.errorMessage) { errorMessage in
-            Alert(
-                title: Text("Failed to log out"),
-                message: Text(errorMessage.errorText),
-                dismissButton: .cancel()
-            )
+            Button("Log Out") {
+                viewModel.isLoggingOut = true
+                Task {
+                    logout()
+                }
+            }.disabled(app.currentUser == nil || viewModel.isLoggingOut)
+            // Show an alert if there is an error during logout
+                .alert(item: $viewModel.errorMessage) { errorMessage in
+                Alert(
+                    title: Text("Failed to log out"),
+                    message: Text(errorMessage.errorText),
+                    dismissButton: .cancel()
+                )
+            }
         }
     }
-    
+
     // log the user out, or display an alert with an error if logout fails.
     func logout() {
         Task{

--- a/App/Views/ContentView.swift
+++ b/App/Views/ContentView.swift
@@ -1,16 +1,16 @@
 import SwiftUI
 
 struct ContentView: View {
-    @EnvironmentObject var errorHandler: ErrorHandler
-    @EnvironmentObject var viewModel: ItemsViewModel
-    
-    @ObservedObject var app: CBLApp
+    @Environment(ErrorHandler.self) private var errorHandler
+    @Environment(ItemsViewModel.self) private var viewModel
+
+    let app: CBLApp
 
     var body: some View {
         if app.currentUser != nil {
             OpenDatabaseView()
-                .environmentObject(errorHandler)
-                .environmentObject(viewModel)
+                .environment(errorHandler)
+                .environment(viewModel)
         } else {
             // If there is no user logged in, show the login view.
             LoginView()

--- a/App/Views/CreateItemView.swift
+++ b/App/Views/CreateItemView.swift
@@ -38,6 +38,7 @@ struct CreateItemView: View {
                         Spacer()
                     }
                 }
+                .alignmentGuide(.listRowSeparatorLeading) { _ in 0 }
                 Button(action: {
                     // If the user cancels, we don't want to
                     // append the new object we created to the
@@ -51,6 +52,7 @@ struct CreateItemView: View {
                         Spacer()
                     }
                 }
+                .alignmentGuide(.listRowSeparatorLeading) { _ in 0 }
             }
         }
         .navigationBarTitle("Add Item")

--- a/App/Views/CreateItemView.swift
+++ b/App/Views/CreateItemView.swift
@@ -1,15 +1,19 @@
 import SwiftUI
 
 struct CreateItemView: View {
-    @EnvironmentObject var viewModel:CreateItemViewModel
-    
+    @Environment(CreateItemViewModel.self) private var viewModel
+
     // We've passed in the ``creatingNewItem`` variable
     // from the ItemsView to know when the user is done
     // with the new Item and we should return to the ItemsView.
     @Binding var isInCreateItemView: Bool
 
     var body: some View {
-        Form {
+        // `@Bindable` is what makes `$viewModel.itemSummary` available for an
+        // `@Observable` object resolved from the environment.
+        @Bindable var viewModel = viewModel
+
+        return Form {
             Section(header: Text("Item Name")) {
                 TextField("New item", text: $viewModel.itemSummary)
             }
@@ -21,12 +25,12 @@ struct CreateItemView: View {
                     Task {
                         await viewModel.createItem()
                     }
-                    
+
                     // Now we're done with this view, so set the
                     // ``isInCreateItemView`` variable to false to
                     // return to the ItemsView.
                     isInCreateItemView = false
-                    
+
                 }) {
                     HStack {
                         Spacer()

--- a/App/Views/ItemsView.swift
+++ b/App/Views/ItemsView.swift
@@ -5,12 +5,17 @@ struct ItemsView: View {
     @Binding var showMyItems: Bool
     @Binding var isInOfflineMode: Bool
     var leadingBarButton: AnyView?
-    
-    @EnvironmentObject var errorHandler: ErrorHandler
-    @EnvironmentObject var viewModel: ItemsViewModel
-    
+
+    @Environment(ErrorHandler.self) private var errorHandler
+    @Environment(ItemsViewModel.self) private var viewModel
+
     var body: some View {
-        NavigationView {
+        // `@Environment` hands back the object but not bindings into it.
+        // `@Bindable` wraps it locally so `$viewModel.someProperty` works, which
+        // is what `@EnvironmentObject` used to provide directly.
+        @Bindable var viewModel = viewModel
+
+        return NavigationView {
             ZStack {
                 VStack {
                     if viewModel.isInCreateItemView {
@@ -31,7 +36,7 @@ struct ItemsView: View {
                             }
                         }
                         isInOfflineMode = !isInOfflineMode
-                        
+
                     } label: {
                         isInOfflineMode ? Image(systemName: "wifi.slash") : Image(systemName: "wifi")
                     }
@@ -58,7 +63,7 @@ struct ItemsView: View {
                             }
                                 .padding()
                                 .multilineTextAlignment(.center)
-                            
+
                         )
                 }
             }

--- a/App/Views/LoginView.swift
+++ b/App/Views/LoginView.swift
@@ -2,11 +2,15 @@ import SwiftUI
 
 /// Log in or register users using email/password authentication
 struct LoginView: View {
-    @EnvironmentObject var viewModel: LoginViewModel
-    @EnvironmentObject var errorHandler: ErrorHandler
+    @Environment(LoginViewModel.self) private var viewModel
+    @Environment(ErrorHandler.self) private var errorHandler
 
     var body: some View {
-        VStack {
+        // `@Bindable` is what makes `$viewModel.email` / `$viewModel.password`
+        // available for an `@Observable` object resolved from the environment.
+        @Bindable var viewModel = viewModel
+
+        return VStack {
             if viewModel.isLoggingIn {
                 ProgressView()
             }

--- a/App/Views/OpenDatabaseView.swift
+++ b/App/Views/OpenDatabaseView.swift
@@ -2,14 +2,16 @@ import SwiftUI
 
 /// Called when login completes. Navigates to the Items screen.
 struct OpenDatabaseView: View {
-    @ObservedObject var cblApp = app
-    
-    @EnvironmentObject var itemsViewModel: ItemsViewModel
-    @EnvironmentObject var viewModel: OpenDatabaseViewModel
+    /// A plain `let` - no `@ObservedObject`. `CBLApp` is `@Observable`, so reading
+    /// `databaseState` inside `body` is enough to re-render when it changes.
+    private let cblApp = app
+
+    @Environment(ItemsViewModel.self) private var itemsViewModel
+    @Environment(OpenDatabaseViewModel.self) private var viewModel
 
     @State var showMyItems = true
     @State var isInOfflineMode = false
-    
+
     var body: some View {
         switch cblApp.databaseState {
             case .notInitialized,
@@ -22,11 +24,14 @@ struct OpenDatabaseView: View {
                     showMyItems: $showMyItems,
                     isInOfflineMode: $isInOfflineMode,
                     leadingBarButton: AnyView(LogoutButton()))
-                
+
                 // showMyItems toggles the query of myItems
                 // When it's toggled on, only the the current users items are shown.
                 // When it's toggled off, *all* items are shown, regardless of the user
-                    .onChange(of: showMyItems) { newValue in
+                //
+                // The single-parameter `onChange` closure is deprecated as of
+                // iOS 17, so this uses the (oldValue, newValue) form.
+                    .onChange(of: showMyItems) { _, newValue in
                         Task {
                             if newValue {
                                 await itemsViewModel.setMyItems()
@@ -44,7 +49,7 @@ struct OpenDatabaseView: View {
                 // While sync is not available, items can still be written and queried.
                 // When sync is resumed, items created or updated offline will upload to
                 // the server and changes from the server or other devices will be downloaded to the client.
-                    .onChange(of: isInOfflineMode) { newValue in
+                    .onChange(of: isInOfflineMode) { _, newValue in
                         Task {
                             newValue ? await viewModel.pauseSync() : await viewModel.resumeSync()
                         }

--- a/App/capellaConfig.plist
+++ b/App/capellaConfig.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>endpointUrl</key>
-	<string>wss://1oooidqy0vm9-t3y.apps.cloud.couchbase.com:4984/tasks</string>
+	<string>wss://oht6b3-3tm0um93i.apps.cloud.couchbase.com:4984/tasks</string>
 	<key>capellaUrl</key>
 	<string>https://cloud.capella.com</string>
 </dict>

--- a/App/capellaConfig.plist
+++ b/App/capellaConfig.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>endpointUrl</key>
-	<string>wss://oht6b3-3tm0um93i.apps.cloud.couchbase.com:4984/tasks</string>
+	<string>wss://&lt;your-endpoint-host&gt;:4984/tasks</string>
 	<key>capellaUrl</key>
 	<string>https://cloud.capella.com</string>
 </dict>

--- a/Capella.md
+++ b/Capella.md
@@ -86,4 +86,11 @@ Copy the Public Connection URL that is provided.  This will be used in the mobil
 
 Now open the `capellaConfig.plist` file, which is located in the App folder.
 
-Update the `endpointUrl` value with the Public Connection URL you copied from the App Endpoint.  
+Replace the placeholder `endpointUrl` value with the Public Connection URL you copied from the App Endpoint:
+
+```xml
+<key>endpointUrl</key>
+<string>wss://&lt;your-endpoint-host&gt;:4984/tasks</string>
+```
+
+The app cannot sync until this placeholder is replaced.  

--- a/Capella.md
+++ b/Capella.md
@@ -25,6 +25,14 @@ Click the Create button to create the new Scope and Collection.
 
 Once you have followed the directions for setting up your bucket, follow the [directions for setting up App Services](https://docs.couchbase.com/cloud/get-started/create-account.html#app-services).
 
+> [!IMPORTANT]
+> Select an App Services version of **4.0 or later**.  This app uses Couchbase Lite 4.1, which negotiates a replication protocol (`BLIP_3+CBMobile_4`) that only App Services 4.0 and later support.  
+>
+> To check the version of an App Endpoint you have already created, open its Public Connection URL over HTTPS in a browser - for example `https://<your-endpoint-host>:4984/` - which reports the Sync Gateway version it is running.
+>
+> If only a 3.x App Service is available to you, use Couchbase Lite 3.3.x in the app instead.  See the [Requirements](./README.md#requirements) section of the README.
+>
+
 ## Setup App Services Endpoint
 
 Click the App Services tab and select your created App Service from the Setup App Service Instance step.  The App Endpoints listing should appear.  Click on the + Create App Endpoint to create a new endpoint.
@@ -42,7 +50,7 @@ Click the Create button to create the new App Endpoint.  Note it may take a few 
 
 The [Access Control and Data Validation](https://docs.couchbase.com/cloud/app-services/deployment/access-control-data-validation.html) is used to setup access control policies for the App Endpoint. In the case of the app, [script](https://github.com/couchbaselabs/cbl-realm-template-app-swiftui-todo/blob/main/sync.js) specifies the policies to ensure that only the task owner can update corresponding task, while allowing a user to read all tasks.
 
-From the App Endpoints list, click on your newly created App Endpoint `tasks`.  From the Access Control and Validation screen, click the linked collections `tasks`.  Follow the following steps:
+From the App Endpoints list, click on your newly created App Endpoint `tasks`.  Click the **Security** tab, select **Access and Validation** from the navigation menu on the left, and then click the linked collection `tasks`.  Follow the following steps:
 
 - Click the Import from File button.  
 - Browse to the repo where you downloaded the code and select the [sync.js](https://github.com/couchbaselabs/cbl-realm-template-app-swiftui-todo/blob/main/sync.js) file located in the root of the project.  Click the Import button to import the Sync Function. 

--- a/README.md
+++ b/README.md
@@ -143,8 +143,6 @@ Three details about this class are worth calling out:
 - **`Item` has to be a `class`, not a `struct`.** The Codable document APIs (`Collection.save(from:)`, `Collection.delete(for:)`) are constrained to `AnyObject`; the SDK declares `typealias DocumentCodable = Codable & AnyObject`.
 - **`isComplete` is optional (`Bool?`).** Swift's generated decoder fails outright if a key for a non-optional property is missing, and because a result set is decoded in a single `data(as:)` call, one document without `isComplete` would fail the whole batch and leave the list empty. Optional lets those documents decode, with `nil` treated as "not complete" where it is displayed.
 
-An earlier version of this app carried an `ItemDao` wrapper to unwrap `SELECT *` query results and a hand-written `toJSON()` method. Naming the query columns and using the Codable APIs made both unnecessary, and they were removed.
-
 ## Database Service 
 
 A new [DatabaseService](https://github.com/couchbaselabs/cbl-realm-template-app-swiftui-todo/blob/main/App/Data/DatabaseService.swift) was created to handle interactions between the Couchbase Lite Database, Collection, and Replicator and the rest of the application.  
@@ -219,7 +217,7 @@ self.queryMyTasks = try db.createQuery(queryString)
 ```
 
 > [!IMPORTANT]
-> The columns are named explicitly rather than using `SELECT *`, and `meta().id AS id` is selected deliberately. A document's ID lives in its metadata, not in its body, so `SELECT *` does not return it and the `@DocumentID` property on `Item` would silently decode as `nil`. Every code path that needs the document ID afterwards - `deleteTask` and `updateItem` both do - would then fail. Naming the columns also means each result row maps straight onto `Item`, which is what removed the need for the `ItemDao` wrapper.
+> The columns are named explicitly rather than using `SELECT *`, and `meta().id AS id` is selected deliberately. A document's ID lives in its metadata, not in its body, so `SELECT *` does not return it and the `@DocumentID` property on `Item` would silently decode as `nil`. Every code path that needs the document ID afterwards - `deleteTask` and `updateItem` both do - would then fail. Naming the columns also means each result row maps straight onto `Item`, with no wrapper object needed to unwrap a `SELECT *` alias.
 >
 
 Caching queries aren't required, but can save on resources if the same query is run multiple times. 
@@ -271,7 +269,7 @@ self._replicator?.changePublisher()
   .store(in: &cancellables)
 ```
 
-The earlier version of this app called `addChangeListener`, held on to the returned `ListenerToken`, and removed it by hand in `close()`. The publisher replaces all of that. `store(in:)` hands the subscription to a `Set<AnyCancellable>` owned by the service, and releasing that set cancels the underlying listener:
+`store(in:)` hands the subscription to a `Set<AnyCancellable>` owned by the service, and releasing that set cancels the underlying listener, so there is no token to track:
 
 ```swift
 //Combine subscriptions owned by this service. `AnyCancellable` cancels its
@@ -289,12 +287,7 @@ Publishers also deliver on the main queue by default, so the `DispatchQueue.main
 The [addTask function](https://github.com/couchbaselabs/cbl-realm-template-app-swiftui-todo/blob/main/App/Data/DatabaseService.swift) was created to add a task to the CouchbaseLite Database using the Codable API.  The method is shown below:
 
 ```swift
-guard let currentuser = app.currentUser
-else {
-  app.setError(InvalidCredentialsException(
-    message: "User is not logged in."))
-  return
-}
+guard let currentuser = requireCurrentUser() else { return }
 guard let collection = taskCollection
 else {
   app.setError(InvalidStateError(
@@ -308,9 +301,7 @@ let task = Item(
 
 try collection.save(from: task)
 ```
-`save(from:)` encodes the object and writes it in a single step. `task.id` is `nil` at this point, so Couchbase Lite generates a document ID and assigns it back to the `@DocumentID` property.  If an error occurs, `app.setError` is called with the exception that was thrown.
-
-The earlier version of this app serialized the object to a JSON string with a hand-written `toJSON()` method and wrapped it in a [MutableDocument](https://docs.couchbase.com/couchbase-lite/current/swift/document.html#create-a-document) before saving. Neither step is needed with the Codable API.
+`requireCurrentUser()` is a small private helper that returns the signed-in `User` or sets an `InvalidCredentialsException` and returns `nil`; it returns the user rather than a `Bool` because each caller needs the `username` as well as the check.  `save(from:)` encodes the object and writes it in a single step. `task.id` is `nil` at this point, so Couchbase Lite generates a document ID and assigns it back to the `@DocumentID` property.  If an error occurs, `app.setError` is called with the exception that was thrown.
 
 ### close method
 
@@ -453,12 +444,7 @@ Four details of this subscription are worth calling out:
 The updateItem function is used to update a task. The stored document is read back so that its owner can be checked, the new values are applied to the `Item`, and the object is written with the Codable `save(from:)` function. A security check was added so that only the owner of the task can update the task.
 
 ```swift
-guard let currentuser = app.currentUser
-else {
-  app.setError(InvalidCredentialsException(
-    message: "User is not logged in."))
-  return
-}
+guard let currentuser = requireCurrentUser() else { return }
 guard let collection = taskCollection
 else {
   app.setError(InvalidStateError(

--- a/README.md
+++ b/README.md
@@ -13,9 +13,16 @@ Some UI changes were made to remove wording about Realm and replaced with Couchb
 
 # Requirements
 - Xcode 16.0 or later
+- iOS 17.0 or later - required by the [Observation](https://developer.apple.com/documentation/observation) framework (`@Observable`) that the ViewModels use
+- Couchbase Capella App Services **4.0 or later** - see the warning below
 - Basic [SwiftUI](https://developer.apple.com/xcode/swiftui/) knowledge
 - Basic [Swift Concurrency](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/concurrency/) knowledge
+- Basic [Combine](https://developer.apple.com/documentation/combine) knowledge - Couchbase Lite exposes its reactive APIs as Combine publishers
 - Understanding of the [Realm SDK for SwiftUI](https://www.mongodb.com/docs/atlas/device-sdks/sdk/swift/swiftui/)
+
+> [!WARNING]
+> This app uses Couchbase Lite **4.1.0**, which negotiates the `BLIP_3+CBMobile_4` replication protocol. Only **App Services / Sync Gateway 4.0 and later** speak that protocol. Pointing this app at a 3.x App Endpoint fails *silently* - the WebSocket upgrade is rejected, no checkpoint is ever established, and the task list stays empty with no error surfaced in the app. 
+> If you need to run against a 3.x App Endpoint, use Couchbase Lite 3.3.x instead. Every reactive API described in this document is available from 3.2.3 onwards, so only the version number and the two 4.0 API changes noted below differ.
 
 # Fetching the App Source Code
 
@@ -40,6 +47,13 @@ Several files were changed or added in the conversion process.
 ## Package Dependencies 
 The app Package Dependencies were updated, removing the Realm and Realm Database frameworks.  The CouchbaseLiteSwift framework was added to the project.  The [Couchbase Lite documentation](https://docs.couchbase.com/couchbase-lite/current/swift/gs-install.html#lbl-install-tabs) covers the various methods for adding the CouchbaseLiteSwift library to a new or existing project.  In this project we used Swift Package Manager (SPM).
 
+The package is pinned with the *Up to Next Minor Version* rule, so the project resolves 4.1.x but will not move to 4.2 on its own:
+
+```
+https://github.com/couchbase/couchbase-lite-swift-ee.git
+Up to Next Minor Version: 4.1.0
+```
+
 > [!WARNING]
 > Some XCode users have reported issues restoring the SPM dependencies.  If you have issues, you might need to reset your package cache.  When searching the internet on this problem, most “solutions” on the forums revolve around some magical combination:
 > - Cleaning your project (cmd-shift-K)
@@ -49,9 +63,13 @@ The app Package Dependencies were updated, removing the Realm and Realm Database
 > - Running File > Packages > Resolve Package Versions
 > - Closing and re-opening Xcode.
 >
+> Two failures are specific to changing the SDK version in an existing checkout:
+> - If resolution fails with `failed downloading ... already exists in file system`, a partially downloaded artifact is cached. Delete the matching entry under `~/Library/Caches/org.swift.swiftpm/artifacts/` and resolve again.
+> - **Do a clean build (cmd-shift-K) after changing the version.** Some signatures changed between releases in ways that are source-compatible but binary-incompatible - `ValueIndexConfiguration.init` is one - and an incremental build can reuse a stale module cache and fail at link time with an undefined symbol.
+>
 
 ## App Services Configuration File
-The original source code had the configuration for Atlas App Services stored in the atlasConfig.plist file located in the App folder.  This file was removed and the configuration for Capella App Services was added in the [capellaConfig.plist]() file. 
+The original source code had the configuration for Atlas App Services stored in the atlasConfig.plist file located in the App folder.  This file was removed and the configuration for Capella App Services was added in the [capellaConfig.plist](./App/capellaConfig.plist) file. 
 
 You will need to modify this file to add your Couchbase Capella App Services endpoint URL, as outlined in the [Capella setup instructions](./Capella.md).
 
@@ -98,15 +116,49 @@ The Couchbase Lite SDK doesn't provide a user object for tracking the authentica
 
 ## Updating Item Domain Model
 
-The [Item](https://github.com/couchbaselabs/cbl-realm-template-app-swiftui-todo/blob/main/App/Models/Item.swift#L22) file was modified to remove the Realm annotations and to refactor some properties to meet standard Swift conventions for serialization.
+The [Item](https://github.com/couchbaselabs/cbl-realm-template-app-swiftui-todo/blob/main/App/Models/Item.swift) file was modified to remove the Realm annotations and to refactor some properties to meet standard Swift conventions for serialization.
 
-The Item class was changed to support the Codable and Identifiable protocols. The Swift serialization library allows the conversion of the class to a JSON string for storage in Couchbase Lite, so changes were made to the class to make it serializable by the Swift serialization library.
+The Item class supports the Codable and Identifiable protocols, which lets Couchbase Lite read and write it directly - no hand-written JSON conversion and no separate Data Access Object are required.
 
-Finally, a [ItemDAO](https://github.com/couchbaselabs/cbl-realm-template-app-swiftui-todo/blob/main/App/Models/Item.swift#L3) (Data Access Object) was created to help with the deserialization of the Query Results that come back from a SQL++ QueryChange object.
+```swift
+class Item: Codable, Identifiable {
+    @DocumentID var id: String?
+    var isComplete: Bool?
+    var summary: String
+    var ownerId: String
+    ...
+}
+```
+
+Three details about this class are worth calling out:
+
+- **`@DocumentID`** binds `id` to the document's *metadata* ID rather than to a field in the document body. On save, if `id` is `nil`, Couchbase Lite generates a document ID and writes it back to the property, and the ID is never stored inside the JSON body. On read, the property is populated from the `id` column of the query result - which is why the queries below select `meta().id AS id` explicitly.
+- **`Item` has to be a `class`, not a `struct`.** The Codable document APIs (`Collection.save(from:)`, `Collection.delete(for:)`) are constrained to `AnyObject`; the SDK declares `typealias DocumentCodable = Codable & AnyObject`.
+- **`isComplete` is optional (`Bool?`).** Swift's generated decoder fails outright if a key for a non-optional property is missing, and because a result set is decoded in a single `data(as:)` call, one document without `isComplete` would fail the whole batch and leave the list empty. Optional lets those documents decode, with `nil` treated as "not complete" where it is displayed.
+
+An earlier version of this app carried an `ItemDao` wrapper to unwrap `SELECT *` query results and a hand-written `toJSON()` method. Naming the query columns and using the Codable APIs made both unnecessary, and they were removed.
 
 ## Database Service 
 
 A new [DatabaseService](https://github.com/couchbaselabs/cbl-realm-template-app-swiftui-todo/blob/main/App/Data/DatabaseService.swift) was created to handle interactions between the Couchbase Lite Database, Collection, and Replicator and the rest of the application.  
+
+### Logging
+
+The service's initializer turns on console logging:
+
+```swift
+init() {
+    LogSinks.console = ConsoleLogSink(level: .debug)
+}
+```
+
+> [!NOTE]
+> This is the second API that changed in Couchbase Lite 4.0.  `Database.log` was removed; logging is now configured by assigning a sink to `LogSinks`.  On 3.3.x the equivalent is `Database.log.console.level = .debug`.
+>
+> Only a console sink is set here, so log output is visible in Xcode while the app runs but is not kept afterwards.  To keep logs for later inspection - which is worth doing when diagnosing replication - also assign a file sink:
+> ```swift
+> LogSinks.file = FileLogSink(level: .verbose, directory: logDirectory)
+> ```
 
 ### Initialize Couchbase Lite Database and Replication Configuration
 
@@ -144,17 +196,24 @@ try collection.createIndex(
 ```
 
 #### Cached Query Setup 
-Next, two basic queries for the application are created:  One to get the current users tasks and one to get all tasks. Queries are compiled when created from the `db.createQuery` function.  By initializing the query when the service is intialized, we can use the query later in the application without having to recompile the query each time the setTasksListChangeObserver function is run. 
+Next, two basic queries for the application are created:  One to get the current users tasks and one to get all tasks. Queries are compiled when created from the `db.createQuery` function.  By initializing the query when the service is intialized, we can use the query later in the application without having to recompile the query each time the task list is observed. 
 
 ```swift
  //create cache queries used for LiveQuery
-var queryString = "SELECT * FROM data.tasks as item "
-self.queryAllTasks = try db.createQuery(queryString)
+let selectClause =
+  "SELECT meta().id AS id, summary, isComplete, ownerId "
+  + "FROM data.tasks "
+self.queryAllTasks = try db.createQuery(selectClause)
                     
-queryString.append("WHERE item.ownerId = '\(user.username)' ")
+var queryString = selectClause
+queryString.append("WHERE ownerId = '\(user.username)' ")
 queryString.append("ORDER BY META().id ASC")
 self.queryMyTasks = try db.createQuery(queryString)
 ```
+
+> [!IMPORTANT]
+> The columns are named explicitly rather than using `SELECT *`, and `meta().id AS id` is selected deliberately. A document's ID lives in its metadata, not in its body, so `SELECT *` does not return it and the `@DocumentID` property on `Item` would silently decode as `nil`. Every code path that needs the document ID afterwards - `deleteTask` and `updateItem` both do - would then fail. Naming the columns also means each result row maps straight onto `Item`, which is what removed the need for the `ItemDao` wrapper.
+>
 
 Caching queries aren't required, but can save on resources if the same query is run multiple times. 
 
@@ -162,10 +221,20 @@ Caching queries aren't required, but can save on resources if the same query is 
 Next the [Replication Configuration](https://github.com/couchbaselabs/cbl-realm-template-app-swiftui-todo/blob/main/App/Data/DatabaseService.swift#L118) is created using the Endpoint URL that is provided from the resource file described earlier in this document.  The configuration is setup in a [PULL_AND_PUSH](https://docs.couchbase.com/couchbase-lite/current/swift/replication.html#lbl-cfg-sync) configuration which means it will pull changes from the remote database and push changes to Capella App Services. By setting continuous to true the replicator will continue to listen for changes and replicate them.  
 
 ```swift
-var config = ReplicatorConfiguration(target: targetEndpoint)
+//configure the collection to sync
+let collectionConfig = CollectionConfiguration(
+  collection: collection)
+
+//create replicator config
+var config = ReplicatorConfiguration(
+  collections: [collectionConfig], target: targetEndpoint)
 config.replicatorType = .pushAndPull
 config.continuous = true
 ```
+
+> [!NOTE]
+> This is one of the two APIs that changed in Couchbase Lite 4.0. The collection is now supplied *through* `CollectionConfiguration`, and `ReplicatorConfiguration.collections` is read-only, so collections are passed to the initializer. The 3.x form - `ReplicatorConfiguration(target:)` followed by `config.addCollection(collection, config: CollectionConfiguration())` - was removed. On 3.3.x, use that older form instead.
+>
 
 > [!TIP]
 >The Couchbase Lite SDK [Replication Configuration](https://docs.couchbase.com/couchbase-lite/current/swift/replication.html#lbl-cfg-repl) API also supports [filtering of channels](https://docs.couchbase.com/couchbase-lite/current/swift/replication.html#lbl-repl-chan) to limit the data that is replicated to the device. 
@@ -180,67 +249,79 @@ let auth = BasicAuthenticator(
 config.authenticator = auth
 ```
 #### Replicator Status 
-A change listener for [Replication Status](https://docs.couchbase.com/couchbase-lite/current/swift/replication.html#lbl-repl-status) is created and is used to track any errors that might happen. 
+The [Replication Status](https://docs.couchbase.com/couchbase-lite/current/swift/replication.html#lbl-repl-status) is observed through the Replicator's [changePublisher](https://docs.couchbase.com/couchbase-lite/current/swift/reactive.html) - a Combine publisher - and is used to track any errors that might happen. 
 
 ```swift
-//handle listeners for replication status to calculate
-//status change
-self._replicatorStatusToken = self._replicator?.addChangeListener 
-  ({ (change) in
-  DispatchQueue.main.async {
-   if let error = change.status.error {
-     print("replicator error state \(error)")
-   } else {
-     print ("current state \(change.status.activity)" )
-   }
+//observe replication status changes
+self._replicator?.changePublisher()
+  .sink { (change) in
+    if let error = change.status.error {
+      print("replicator error state \(error)")
+    } else {
+      print("current state \(change.status.activity)")
+    }
   }
-})
+  .store(in: &cancellables)
 ```
+
+The earlier version of this app called `addChangeListener`, held on to the returned `ListenerToken`, and removed it by hand in `close()`. The publisher replaces all of that. `store(in:)` hands the subscription to a `Set<AnyCancellable>` owned by the service, and releasing that set cancels the underlying listener:
+
+```swift
+//Combine subscriptions owned by this service. `AnyCancellable` cancels its
+//subscription when it is released, so there are no listener tokens to remove.
+fileprivate var cancellables = Set<AnyCancellable>()
+```
+
+Publishers also deliver on the main queue by default, so the `DispatchQueue.main.async` hop that the listener version needed is no longer there.
 > [!IMPORTANT]
 >Swift Developers should review the [Couchbase Lite SDK documentation for Swift](https://docs.couchbase.com/couchbase-lite/current/swift/replication.html#introduction) prior to making decisions on how to setup the replicator.
 >
 
 ### addTask function 
 
-The [addTask function](https://github.com/couchbaselabs/cbl-realm-template-app-swiftui-todo/blob/main/App/Data/DatabaseService.swift#L176) was created to add a task to the CouchbaseLite Database using JSON serialization.  The method is shown below:
+The [addTask function](https://github.com/couchbaselabs/cbl-realm-template-app-swiftui-todo/blob/main/App/Data/DatabaseService.swift) was created to add a task to the CouchbaseLite Database using the Codable API.  The method is shown below:
 
 ```swift
+guard let currentuser = app.currentUser
+else {
+  app.setError(InvalidCredentialsException(
+    message: "User is not logged in."))
+  return
+}
 guard let collection = taskCollection
- else {
-  app.error = InvalidStateError(
-    message: "taskCollection is not available.")
+else {
+  app.setError(InvalidStateError(
+    message: "taskCollection is not available."))
   return
 }
 let task = Item(
-  isComplete: false, 
-  summary: taskSummary, 
+  isComplete: false,
+  summary: taskSummary,
   ownerId: currentuser.username)
-if let json = task.toJSON() {
-  let mutableDocument = try MutableDocument(id: task.id, json: json)
-  try collection.save(document: mutableDocument)
-} else {
-  app.error = InvalidStateError(
-    message: "item could not be serialized")
-}
+
+try collection.save(from: task)
 ```
-The task is serialized into a JSON string using the Swift serialization library and then saved to the collection via the [MutableDocument](https://docs.couchbase.com/couchbase-lite/current/swift/document.html#create-a-document) object.  If an error occurs, the app.error handler is set with the exception that was thrown.
+`save(from:)` encodes the object and writes it in a single step. `task.id` is `nil` at this point, so Couchbase Lite generates a document ID and assigns it back to the `@DocumentID` property.  If an error occurs, `app.setError` is called with the exception that was thrown.
+
+The earlier version of this app serialized the object to a JSON string with a hand-written `toJSON()` method and wrapped it in a [MutableDocument](https://docs.couchbase.com/couchbase-lite/current/swift/document.html#create-a-document) before saving. Neither step is needed with the Codable API.
 
 ### close method
 
-The close method is used to remove any query listeners, the replication status change listener, stop replication, and then close the database.  This will be called when the user logs out from the application making sure if the application is used by multiple uses to close out all resources before another user logs into the application.
+The close method cancels this service's Combine subscriptions, stops replication, and then closes the database.  This will be called when the user logs out from the application making sure if the application is used by multiple uses to close out all resources before another user logs into the application.
 
 ```swift
 func close() {
  do {
-  self.queryListenerToken?.remove()
-  self._replicatorStatusToken?.remove()
+  self.cancellables.removeAll()
   self._replicator?.stop()
   try self.database?.close()
  } catch {
-  app.error = error
+  app.setError(error)
  }
 }
 ```
+
+Releasing the `AnyCancellable` values cancels the query and replicator subscriptions, so the explicit `queryListenerToken?.remove()` and `_replicatorStatusToken?.remove()` calls that the listener-based version required are gone.
 
 ### Handling Security of Updates/Delete
 
@@ -250,113 +331,158 @@ Couchbase Lite doesn't have the same security model.  In this application the fo
 
 The code of the application was modified to validate that write access is only allowed by users that own the tasks and the Data Access and Validation script was added in the Capella setup instructions that limits whom can write updates.
 
+Ownership is enforced at three levels:
+
+1. **The UI does not offer the action.** [ItemDetail](https://github.com/couchbaselabs/cbl-realm-template-app-swiftui-todo/blob/main/App/Views/Components/ItemDetail.swift) shows the edit fields and the Save button only when the signed-in user owns the task, and [ItemList](https://github.com/couchbaselabs/cbl-realm-template-app-swiftui-todo/blob/main/App/Views/Components/ItemList.swift) attaches the swipe-to-delete action per row, only for rows the signed-in user owns.
+2. **The DatabaseService re-checks before writing.** `deleteTask` and `updateItem` both read the stored document back and compare its `ownerId` against `app.currentUser`, so a call that bypasses the UI is still rejected.
+3. **The Data Access and Validation function rejects the write on the server.** See [sync.js](https://github.com/couchbaselabs/cbl-realm-template-app-swiftui-todo/blob/main/sync.js), which is the only one of the three that also applies to clients other than this app.
+>
+
 > [!TIP]
 > Develoeprs can use a Custom [Replication Conflict Resolution](https://docs.couchbase.com/couchbase-lite/current/android/conflict.html#custom-conflict-resolution) to receive the result in your applications code and then revert the change.
 >
 
 ### deleteTask method
 
-The deleteTask method removes a task from the database.  This is done by retrieving the document from the database using the `collection.document` function and then calling the collection `delete` function.  A security check was added so that only the owner of the task can delete the task.
+The deleteTask method removes a task from the database.  The stored document is read back with the `collection.document` function so that its owner can be checked, and the task is then removed with the Codable `delete(for:)` function.  A security check was added so that only the owner of the task can delete the task.
 
 ```swift
-func deleteTask(item: Item){
+func deleteTask(item: Item) {
   do {
-    guard let collection = taskCollection
+    guard let currentuser = app.currentUser
     else {
-      app.error = InvalidStateError(message: "taskCollection is not available.")
+      app.setError(InvalidCredentialsException(
+        message: "User is not logged in."))
       return
     }
-    guard let doc = try collection.document(id: item.id)
+    guard let collection = taskCollection
     else {
-      app.error = InvalidStateError(message: "document not found")
+      app.setError(InvalidStateError(
+        message: "taskCollection is not available."))
+      return
+    }
+    guard let documentId = item.id
+    else {
+      app.setError(InvalidStateError(
+        message: "item has not been saved and has no document id"))
+      return
+    }
+    guard let doc = try collection.document(id: documentId)
+    else {
+      app.setError(InvalidStateError(message: "document not found"))
       return
     }
     let ownerId = doc.string(forKey: "ownerId")
-    if (ownerId != item.ownerId){
-       throw InvalidStateError(message: "document does not belong 
-       to current user")
+    if ownerId != currentuser.username {
+      throw InvalidStateError(
+        message: "document does not belong to current user")
     }
-    try collection.delete(document: doc)
-    } catch {
-      app.error = error
-   }
-}
-```
-### setTasksListChangeObserver function 
-
-Couchbase Lite doesn't support the various patterns that Realm provides for tracking changes in a Realm.  Instead Couchbase Lite has the [LiveQuery](https://docs.couchbase.com/couchbase-lite/current/swift/query-live.html#activating-a-live-query) API.  A live query is a query that, once activated, remains active and monitors the database for changes; refreshing the result set whenever a change occurs.  Unlike Realm, when a change is detected, the entire query is re-run and the results are updated.   
-
-Couchbase Lite has a different way of handing replication and security than the Atlas Device SDK [Subscription API](https://www.mongodb.com/docs/atlas/device-sdks/sdk/kotlin/sync/subscribe/#subscriptions-overview).  Because of this, two queries were created to pull the information from the database based on the users selection.  One query is for all tasks and the other is for the current users tasks.  The setTasksListChangeObserver function is used to setup the LiveQuery and then call the completion handler with the results of the query so that the ViewModel can update the observed array of items. 
-
-```swift 
-  func setTasksListChangeObserver(subscriptionType: String, observer: (([Item]?) -> Void)?) {
-
-taskLiveQueryObserver = observer
-var query:Query? = nil
-        
-if (taskLiveQueryObserver != nil) {
- //if existing query listener is running, remove it
- if let token =  queryListenerToken {
-  token.remove()
- }
- //figure out which query to run
- if (subscriptionType == Constants.allItems){
-  query = queryAllTasks
- } else {
-  query = queryMyTasks
- }
- if let runQuery = query {
-  queryListenerToken = runQuery
-  .addChangeListener({ [self] ( change ) in
-   var items: [Item] = []
-   if let results = change.results {
-     for result in results {
-      let json = result.toJSON()
-      if let itemDao = ItemDao(json: json){
-       items.append(itemDao.item)
-      } else {
-       print("error deserializing item from query")
-      }
-    }
-    taskLiveQueryObserver?(items)
-    }
-   })
+    try collection.delete(for: item)
+  } catch {
+    app.setError(error)
   }
- } 
 }
 ```
+
+One detail changed alongside the move to `delete(for:)`:
+
+- `item.id` is an `Optional<String>`, because `@DocumentID` is only populated once an item has been saved or read back from a query. It is unwrapped before use rather than passed straight to `collection.document(id:)`.
+
+### Observing the task list with changePublisher
+
+Couchbase Lite doesn't support the various patterns that Realm provides for tracking changes in a Realm.  Instead Couchbase Lite has the [LiveQuery](https://docs.couchbase.com/couchbase-lite/current/swift/query-live.html#activating-a-live-query) API.  A live query is a query that, once activated, remains active and monitors the database for changes; refreshing the result set whenever a change occurs.  Unlike Realm, when a change is detected, the entire query is re-run and the results are updated.
+
+Couchbase Lite has a different way of handing replication and security than the Atlas Device SDK [Subscription API](https://www.mongodb.com/docs/atlas/device-sdks/sdk/kotlin/sync/subscribe/#subscriptions-overview).  Because of this, two queries were created to pull the information from the database based on the users selection.  One query is for all tasks and the other is for the current users tasks.
+
+From release 3.2.3 the SDK exposes live queries as [Combine publishers](https://docs.couchbase.com/couchbase-lite/current/swift/reactive.html), so the DatabaseService no longer owns the observation at all.  It simply returns the appropriate compiled query:
+
+```swift
+func tasksQuery(subscriptionType: String) -> Query? {
+    subscriptionType == Constants.allItems ? queryAllTasks : queryMyTasks
+}
+```
+
+The [ItemsViewModel](https://github.com/couchbaselabs/cbl-realm-template-app-swiftui-todo/blob/main/App/ViewModels/ItemsViewModel.swift) subscribes to that query and keeps its `items` array in step with it:
+
+```swift
+private func observeTasks(subscriptionType: String) async {
+    cancellables.removeAll()
+
+    guard let query = await service.tasksQuery(
+        subscriptionType: subscriptionType)
+    else { return }
+
+    query.changePublisher()
+        .map { change -> [Item] in
+            guard let results = change.results else { return [] }
+            return (try? results.data(as: Item.self)) ?? []
+        }
+        .sink { [weak self] items in
+            self?.items = items
+        }
+        .store(in: &cancellables)
+}
+```
+
+This replaces a `setTasksListChangeObserver(subscriptionType:observer:)` function that took a completion handler, tracked a `ListenerToken`, removed the previous token by hand, and looped over the result set building `Item` values through an `ItemDao`.  The publisher form differs in four ways:
+
+- **There is no token to manage.**  `store(in:)` puts the subscription into the ViewModel's `Set<AnyCancellable>`, and `cancellables.removeAll()` at the top of the function cancels the previous live query - so toggling between "my tasks" and "all tasks" swaps cleanly instead of leaving two queries running.
+- **There is no completion handler.**  The ViewModel owns the subscription, so it - not the DatabaseService - decides when observation starts and stops.
+- **Decoding is a single call.**  `results.data(as: Item.self)` decodes the whole result set into `[Item]`, replacing the per-row loop and the `ItemDao` wrapper.
+- **Delivery is already on the main queue.**  `changePublisher(on:)` defaults to `.main`.
+
+> [!IMPORTANT]
+> The subscription has to be stored.  A Combine publisher does nothing until something subscribes to it, and the subscription is cancelled as soon as its `AnyCancellable` is released - so discarding the result of `sink` means the live query never fires at all.
+>
+
+> [!NOTE]
+> The SDK also provides `Collection.changePublisher()`, `Collection.documentChangePublisher(for:)`, `Replicator.changePublisher()` and `Replicator.documentReplicationPublisher()`.  This app uses the query and replicator-status publishers.  `documentChangePublisher(for:)` would be the way to make the [ItemDetail](https://github.com/couchbaselabs/cbl-realm-template-app-swiftui-todo/blob/main/App/Views/Components/ItemDetail.swift) view update while it is open, which it currently does not do - it takes a snapshot of the task when it appears.
+>
 
 > [!IMPORTANT]
 >Developers should review the Couchbase Capella App Services [channels](https://docs.couchbase.com/cloud/app-services/channels/channels.html) and [roles](https://docs.couchbase.com/cloud/app-services/user-management/create-app-role.html) documentation to understand the security model it provides prior to planning an application migration. 
 >
 
 ### updateItem function 
-The updateItem function is used to update a task. This is done by retrieving the document from the database using the collection.getDocument method and then updating the document with the new value for the isComplete and summary property. A security check was added so that only the owner of the task can update the task.  The document is then saved back to the collection.
-
-Swift serialization could have been used to perform this update, but is inefficient as only two properties are updated and seralization of the entire object would cost more resources.  
+The updateItem function is used to update a task. The stored document is read back so that its owner can be checked, the new values are applied to the `Item`, and the object is written with the Codable `save(from:)` function. A security check was added so that only the owner of the task can update the task.
 
 ```swift
+guard let currentuser = app.currentUser
+else {
+  app.setError(InvalidCredentialsException(
+    message: "User is not logged in."))
+  return
+}
 guard let collection = taskCollection
 else {
   app.setError(InvalidStateError(
-  message: "taskCollection is not available."))
+    message: "taskCollection is not available."))
   return
 }
-guard let doc = try collection.document(id: item.id)
+guard let documentId = item.id
+else {
+  app.setError(InvalidStateError(
+    message: "item has not been saved and has no document id"))
+  return
+}
+guard let doc = try collection.document(id: documentId)
 else {
   app.setError(InvalidStateError(message: "document not found"))
   return
 }
 let ownerId = doc.string(forKey: "ownerId")
-if ownerId != item.ownerId {
+if ownerId != currentuser.username {
   throw InvalidStateError(
     message: "document does not belong to current user")
 }
-let mutableDoc = doc.toMutable()
-mutableDoc.setBoolean(isComplete, forKey: "isComplete")
-mutableDoc.setString(summary, forKey: "summary")
-try collection.save(document: mutableDoc)
+item.isComplete = isComplete
+item.summary = summary
+try collection.save(from: item)
 ```
+
+The earlier version of this app read the document into a MutableDocument with `doc.toMutable()` and set each field individually with `setBoolean` and `setString`, on the grounds that serializing a whole object to change two properties was wasteful. `save(from:)` writes the whole object instead, which keeps this function consistent with `addTask` and removes the last place where field names were repeated as string literals - at the cost of re-encoding the fields that did not change.
+
+The document is located by `item.id`, which is only populated because the query selects `meta().id AS id`. 
 ## Other Application Changes
 
 ### Rename OpenRealmView 
@@ -378,6 +504,41 @@ Several new ViewModels were added to the application to interact between the Vie
 - [LoginViewModel](https://github.com/couchbaselabs/cbl-realm-template-app-swiftui-todo/blob/main/App/ViewModels/LoginViewModel.swift) - handles authenticating of the user from the [LoginView](https://github.com/couchbaselabs/cbl-realm-template-app-swiftui-todo/blob/main/App/Views/LoginView.swift) and calling the initalization of the database.
 - [LogoutViewModel](https://github.com/couchbaselabs/cbl-realm-template-app-swiftui-todo/blob/main/App/ViewModels/LogoutViewModel.swift) - handles logging the user out of the application including closing all database resources from the [LogoutButton](https://github.com/couchbaselabs/cbl-realm-template-app-swiftui-todo/blob/main/App/Views/Components/LogoutButton.swift).  
 - [OpenDatabaseViewModel](https://github.com/couchbaselabs/cbl-realm-template-app-swiftui-todo/blob/main/App/ViewModels/OpenDatabaseViewModel.swift) - used for stopping and starting replication to simulate the user going offline and online which is done via a button in the [OpenDatabaseView](https://github.com/couchbaselabs/cbl-realm-template-app-swiftui-todo/blob/main/App/Views/OpenDatabaseView.swift#L50). 
+
+#### Observation
+
+All of these ViewModels - along with [CBLApp](https://github.com/couchbaselabs/cbl-realm-template-app-swiftui-todo/blob/main/App/Data/CBLApp.swift) and the `ErrorHandler` in [App.swift](https://github.com/couchbaselabs/cbl-realm-template-app-swiftui-todo/blob/main/App/App.swift) - use the [Observation](https://developer.apple.com/documentation/observation) framework's `@Observable` macro rather than `ObservableObject` with `@Published`:
+
+```swift
+@Observable
+@MainActor
+class ItemsViewModel {
+    var items: [Item] = []
+    ...
+}
+```
+
+The Views changed to match: `@StateObject` became `@State`, `@EnvironmentObject` became `@Environment(SomeViewModel.self)`, `.environmentObject(_:)` became `.environment(_:)`, and `@ObservedObject` was dropped where the object is only read.  Because Observation tracks each property individually on any `@Observable` instance a View reads during `body`, reading `app.currentUser` now registers the View for updates without a property wrapper.
+
+Two consequences are worth knowing about:
+
+- **Every type resolved through `@Environment` must be `@Observable`**, even when it holds no mutable state.  `ItemDetailViewModel` and `OpenDatabaseViewModel` only forward a call to the DatabaseService, but `@Environment(ItemDetailViewModel.self)` will not compile unless the type carries the macro.
+- **`@Environment` supplies the object but not bindings into it.**  Where a View needs `$viewModel.someProperty` for a `TextField` or `Toggle`, it declares a local `@Bindable` shadow first - which is what `@EnvironmentObject` used to provide directly:
+
+```swift
+var body: some View {
+    @Bindable var viewModel = viewModel
+
+    return Form {
+        TextField("New item", text: $viewModel.itemSummary)
+        ...
+    }
+}
+```
+
+> [!NOTE]
+> `@Observable` requires iOS 17 or later, which is why this app's deployment target was raised to 17.0.  To support iOS 15 or 16, keep `ObservableObject` with `@Published` instead - the Combine pipeline described above feeds `@Published` properties just as well, and nothing else in this document changes.
+>
 
 ### Updated ItemDetail view
 The ItemDetail view was updated to add a button for saving the task updates that are performed on the view.  The new button calls the ItemDetailViewModel to update the task in the database.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Some UI changes were made to remove wording about Realm and replaced with Couchb
 - Basic [SwiftUI](https://developer.apple.com/xcode/swiftui/) knowledge
 - Basic [Swift Concurrency](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/concurrency/) knowledge
 - Basic [Combine](https://developer.apple.com/documentation/combine) knowledge - Couchbase Lite exposes its reactive APIs as Combine publishers
-- Understanding of the [Realm SDK for SwiftUI](https://www.mongodb.com/docs/atlas/device-sdks/sdk/swift/swiftui/)
+- Understanding of the [Couchbase Lite SDK for Swift](https://docs.couchbase.com/couchbase-lite/current/swift/quickstart.html)
 
 > [!WARNING]
 > This app uses Couchbase Lite **4.1.0**, which negotiates the `BLIP_3+CBMobile_4` replication protocol. Only **App Services / Sync Gateway 4.0 and later** speak that protocol. Pointing this app at a 3.x App Endpoint fails *silently* - the WebSocket upgrade is rejected, no checkpoint is ever established, and the task list stays empty with no error surfaced in the app. 
@@ -71,7 +71,14 @@ Up to Next Minor Version: 4.1.0
 ## App Services Configuration File
 The original source code had the configuration for Atlas App Services stored in the atlasConfig.plist file located in the App folder.  This file was removed and the configuration for Capella App Services was added in the [capellaConfig.plist](./App/capellaConfig.plist) file. 
 
-You will need to modify this file to add your Couchbase Capella App Services endpoint URL, as outlined in the [Capella setup instructions](./Capella.md).
+The file ships with a placeholder endpoint:
+
+```xml
+<key>endpointUrl</key>
+<string>wss://&lt;your-endpoint-host&gt;:4984/tasks</string>
+```
+
+You will need to replace this placeholder with your own Couchbase Capella App Services endpoint URL, as outlined in the [Capella setup instructions](./Capella.md), before the app can sync.
 
 ##  realmSwiftUIApp changes and CBLiteApp
 The original source code had the SwiftUI.App [Application](https://github.com/couchbaselabs/cbl-realm-template-app-swiftui-todo/blob/main/App/App.swift#L4) inheriting from a custom realmSwiftUIApp that creates a local RMLApp instance app.
@@ -339,22 +346,17 @@ Ownership is enforced at three levels:
 >
 
 > [!TIP]
-> Develoeprs can use a Custom [Replication Conflict Resolution](https://docs.couchbase.com/couchbase-lite/current/android/conflict.html#custom-conflict-resolution) to receive the result in your applications code and then revert the change.
+> Developers can use a Custom [Replication Conflict Resolution](https://docs.couchbase.com/couchbase-lite/current/android/conflict.html#custom-conflict-resolution) to receive the result in your applications code and then revert the change.
 >
 
 ### deleteTask method
 
-The deleteTask method removes a task from the database.  The stored document is read back with the `collection.document` function so that its owner can be checked, and the task is then removed with the Codable `delete(for:)` function.  A security check was added so that only the owner of the task can delete the task.
+The deleteTask method removes a task from the database.  The stored document is read back with the `collection.document` function so that its owner can be checked, and that same `Document` is then passed to `collection.delete(document:)`.  A security check was added so that only the owner of the task can delete the task.
 
 ```swift
 func deleteTask(item: Item) {
   do {
-    guard let currentuser = app.currentUser
-    else {
-      app.setError(InvalidCredentialsException(
-        message: "User is not logged in."))
-      return
-    }
+    guard let currentuser = requireCurrentUser() else { return }
     guard let collection = taskCollection
     else {
       app.setError(InvalidStateError(
@@ -369,7 +371,7 @@ func deleteTask(item: Item) {
     }
     guard let doc = try collection.document(id: documentId)
     else {
-      app.setError(InvalidStateError(message: "document not found"))
+      // Already gone - nothing to do, and nothing to report.
       return
     }
     let ownerId = doc.string(forKey: "ownerId")
@@ -377,16 +379,17 @@ func deleteTask(item: Item) {
       throw InvalidStateError(
         message: "document does not belong to current user")
     }
-    try collection.delete(for: item)
+    try collection.delete(document: doc)
   } catch {
     app.setError(error)
   }
 }
 ```
 
-One detail changed alongside the move to `delete(for:)`:
+Two details are worth noting:
 
 - `item.id` is an `Optional<String>`, because `@DocumentID` is only populated once an item has been saved or read back from a query. It is unwrapped before use rather than passed straight to `collection.document(id:)`.
+- A document that has already been deleted is treated as success rather than as an error. It may have been deleted on another device and that deletion pulled down by replication, in which case the requested end state has already been reached. `delete(document:)` is used rather than the Codable `delete(for:)` for the same reason: the ownership check already holds the `Document`, so no second read is needed, and passing it is idempotent if replication removes the document between the check and the delete. `delete(for:)` fails that race with *"Cannot delete a document that has not yet been saved."*
 
 ### Observing the task list with changePublisher
 
@@ -424,19 +427,22 @@ private func observeTasks(subscriptionType: String) async {
 }
 ```
 
-This replaces a `setTasksListChangeObserver(subscriptionType:observer:)` function that took a completion handler, tracked a `ListenerToken`, removed the previous token by hand, and looped over the result set building `Item` values through an `ItemDao`.  The publisher form differs in four ways:
+Four details of this subscription are worth calling out:
 
-- **There is no token to manage.**  `store(in:)` puts the subscription into the ViewModel's `Set<AnyCancellable>`, and `cancellables.removeAll()` at the top of the function cancels the previous live query - so toggling between "my tasks" and "all tasks" swaps cleanly instead of leaving two queries running.
-- **There is no completion handler.**  The ViewModel owns the subscription, so it - not the DatabaseService - decides when observation starts and stops.
-- **Decoding is a single call.**  `results.data(as: Item.self)` decodes the whole result set into `[Item]`, replacing the per-row loop and the `ItemDao` wrapper.
+- **The subscription's lifetime belongs to the ViewModel.**  `store(in:)` puts it into the ViewModel's `Set<AnyCancellable>`, and `cancellables.removeAll()` at the top of the function cancels the previous live query - so toggling between "my tasks" and "all tasks" swaps cleanly instead of leaving two queries running.
+- **The ViewModel decides when observation starts and stops.**  Because it holds the cancellable, the DatabaseService does not need to track the observation on its behalf.
+- **Decoding is a single call.**  `results.data(as: Item.self)` decodes the whole result set into `[Item]`.
 - **Delivery is already on the main queue.**  `changePublisher(on:)` defaults to `.main`.
 
 > [!IMPORTANT]
 > The subscription has to be stored.  A Combine publisher does nothing until something subscribes to it, and the subscription is cancelled as soon as its `AnyCancellable` is released - so discarding the result of `sink` means the live query never fires at all.
 >
 
-> [!NOTE]
-> The SDK also provides `Collection.changePublisher()`, `Collection.documentChangePublisher(for:)`, `Replicator.changePublisher()` and `Replicator.documentReplicationPublisher()`.  This app uses the query and replicator-status publishers.  `documentChangePublisher(for:)` would be the way to make the [ItemDetail](https://github.com/couchbaselabs/cbl-realm-template-app-swiftui-todo/blob/main/App/Views/Components/ItemDetail.swift) view update while it is open, which it currently does not do - it takes a snapshot of the task when it appears.
+> [!TIP]
+> This app subscribes to two of the publishers the SDK offers - the query publisher shown above and `Replicator.changePublisher()` for replication status.  The SDK also provides `Collection.changePublisher()`, `Collection.documentChangePublisher(for:)` and `Replicator.documentReplicationPublisher()`, which are worth considering as the app grows:
+>
+> - **`documentChangePublisher(for:)`** would make the [ItemDetail](https://github.com/couchbaselabs/cbl-realm-template-app-swiftui-todo/blob/main/App/Views/Components/ItemDetail.swift) view live.  It currently takes a snapshot of the task when it appears, so an edit arriving from another device while the view is open is not reflected until the view is reopened.  Subscribing to changes for that one document ID would keep the open view in step with the database.
+> - **`documentReplicationPublisher()`** reports the outcome of each document push or pull, including rejections.  A write that the Sync Function rejects - for example an attempt to modify a task owned by another user - is currently invisible to the app; subscribing would let it surface the failure to the user.
 >
 
 > [!IMPORTANT]
@@ -479,8 +485,6 @@ item.isComplete = isComplete
 item.summary = summary
 try collection.save(from: item)
 ```
-
-The earlier version of this app read the document into a MutableDocument with `doc.toMutable()` and set each field individually with `setBoolean` and `setString`, on the grounds that serializing a whole object to change two properties was wasteful. `save(from:)` writes the whole object instead, which keeps this function consistent with `addTask` and removes the last place where field names were repeated as string literals - at the cost of re-encoding the fields that did not change.
 
 The document is located by `item.id`, which is only populated because the query selects `meta().id AS id`. 
 ## Other Application Changes

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ Publishers also deliver on the main queue by default, so the `DispatchQueue.main
 The [addTask function](https://github.com/couchbaselabs/cbl-realm-template-app-swiftui-todo/blob/main/App/Data/DatabaseService.swift) was created to add a task to the CouchbaseLite Database using the Codable API.  The method is shown below:
 
 ```swift
-guard let currentuser = requireCurrentUser() else { return }
+guard let currentUser = requireCurrentUser() else { return }
 guard let collection = taskCollection
 else {
   app.setError(InvalidStateError(
@@ -297,7 +297,7 @@ else {
 let task = Item(
   isComplete: false,
   summary: taskSummary,
-  ownerId: currentuser.username)
+  ownerId: currentUser.username)
 
 try collection.save(from: task)
 ```
@@ -347,7 +347,7 @@ The deleteTask method removes a task from the database.  The stored document is 
 ```swift
 func deleteTask(item: Item) {
   do {
-    guard let currentuser = requireCurrentUser() else { return }
+    guard let currentUser = requireCurrentUser() else { return }
     guard let collection = taskCollection
     else {
       app.setError(InvalidStateError(
@@ -366,7 +366,7 @@ func deleteTask(item: Item) {
       return
     }
     let ownerId = doc.string(forKey: "ownerId")
-    if ownerId != currentuser.username {
+    if ownerId != currentUser.username {
       throw InvalidStateError(
         message: "document does not belong to current user")
     }
@@ -444,7 +444,7 @@ Four details of this subscription are worth calling out:
 The updateItem function is used to update a task. The stored document is read back so that its owner can be checked, the new values are applied to the `Item`, and the object is written with the Codable `save(from:)` function. A security check was added so that only the owner of the task can update the task.
 
 ```swift
-guard let currentuser = requireCurrentUser() else { return }
+guard let currentUser = requireCurrentUser() else { return }
 guard let collection = taskCollection
 else {
   app.setError(InvalidStateError(
@@ -463,7 +463,7 @@ else {
   return
 }
 let ownerId = doc.string(forKey: "ownerId")
-if ownerId != currentuser.username {
+if ownerId != currentUser.username {
   throw InvalidStateError(
     message: "document does not belong to current user")
 }

--- a/sync.js
+++ b/sync.js
@@ -1,17 +1,19 @@
 function (doc, oldDoc, meta) {
-	// Check if ownerId exists. You can optionally add validation for other parameters
-	 if (doc.ownerId != null) {
-	   // Check that the user updating document is the owner of the document
-	   // All doc updates via Capella are treated as admin user and will bypass requireUser() check
-	   requireUser (doc.ownerId);
-	   // Assign the document to public channel,"!". All users have automatic access to documents in
-	   // public channel. 
-	   // If you want to restrict user access to a specific channel you can specify that here and 
-	   // then grant user access to that channel via access() API
-	   channel ("!");
-	 }
-	 else {
-	   // If no ownerId, reject the document
-		 throw({forbidden:"Document rejected as it does not have ownerId "});
-	 }
-   }
+
+  var ownerId = doc._deleted ? (oldDoc && oldDoc.ownerId) : doc.ownerId;
+
+  if (ownerId != null) {
+    // Only the owner may write or delete their own task.
+    requireUser(ownerId);
+
+    // Assign the document to the public channel, "!". All users have automatic
+    // access to the public channel, so every user can read every task.
+    // To restrict reads instead, route to a per-user channel here and grant access
+    // to it with the access() API, e.g.:
+    //   channel("user-" + ownerId);
+    //   access(ownerId, "user-" + ownerId);
+    channel("!");
+  } else {
+    throw({ forbidden: "Document rejected as it does not have ownerId " });
+  }
+}

--- a/sync.js
+++ b/sync.js
@@ -1,19 +1,24 @@
 function (doc, oldDoc, meta) {
-
   var ownerId = doc._deleted ? (oldDoc && oldDoc.ownerId) : doc.ownerId;
-
-  if (ownerId != null) {
-    // Only the owner may write or delete their own task.
-    requireUser(ownerId);
-
-    // Assign the document to the public channel, "!". All users have automatic
-    // access to the public channel, so every user can read every task.
-    // To restrict reads instead, route to a per-user channel here and grant access
-    // to it with the access() API, e.g.:
-    //   channel("user-" + ownerId);
-    //   access(ownerId, "user-" + ownerId);
-    channel("!");
-  } else {
+  if (ownerId == null) {
     throw({ forbidden: "Document rejected as it does not have ownerId " });
   }
+
+  // Only the owner may write or delete their own task.
+  requireUser(ownerId);
+
+  // If the task already exists, the user must also be its current owner.
+  // This stops a user from taking over another user's task by writing
+  // their own username into ownerId.
+  if (oldDoc && !oldDoc._deleted) {
+    requireUser(oldDoc.ownerId);
+  }
+
+  // Assign the document to the public channel, "!". All users have automatic
+  // access to the public channel, so every user can read every task.
+  // To restrict reads instead, route to a per-user channel here and grant access
+  // to it with the access() API, e.g.:
+  //   channel("user-" + ownerId);
+  //   access(ownerId, "user-" + ownerId);
+  channel("!");
 }


### PR DESCRIPTION
Updated the SwiftUI Todo app to use reactive patterns, replacing the
callback- and closure-based observation used previously. Also bumped Couchbase Lite
from to 4.1.0 and adopted Swift's Observation framework in place of
`ObservableObject`/`@Published`.

- **Minimum versions raised** — iOS 17 (required by Observation) and App Services /
  Sync Gateway 4.0+. 

- **Reactive data flow** — `ItemsViewModel` subscribes to `query.changePublisher()`
  and `DatabaseService` to `replicator.changePublisher()`, replacing change-listener
  callbacks. All six view models are now `@Observable` and injected via
  `.environment(...)`.

- **Model simplified with `@DocumentID`** — removed the hand-written `Codable`
  implementation, `CodingKeys`, `toJSON()`, and the `ItemDao` wrapper. Queries now
  select `meta().id AS id`, and `isComplete` is optional so a document missing the
  field doesn't fail the whole result set.

- **Fixed ownership enforcement** — `deleteTask` and `updateItem` read `ownerId` but
  never checked it, letting any user modify another user's task. Now enforced in the
  view model, in the UI (per-row `.swipeActions` instead of `.onDelete`), and in
  `sync.js`, which was also validating against `oldDoc` on inserts.